### PR TITLE
[NO-TICKET] hotfix: add google api key to prod build env

### DIFF
--- a/.github/workflows/deploy-web-prod.yml
+++ b/.github/workflows/deploy-web-prod.yml
@@ -27,6 +27,7 @@ jobs:
         run: npm run build
         env:
           VITE_API_URL: ${{ secrets.VITE_API_URL }}
+          VITE_GOOGLE_API_KEY: ${{ secrets.VITE_GOOGLE_API_KEY }}
 
       - name: Install Railway
         run: npm install -g @railway/cli


### PR DESCRIPTION
## Ticket
N/A

## Description
This pull request fixes an issue where the Google Maps API Key was not available during the _deploy web prod_ CI step.

### What
The Google Maps API Key was added to the deploy web prod GitHub Actions config file.

### Why
The application was built without the API Key so users could not access the map.

### Resources
N/A

## Checklists

- [x] [Does this change abide by quality standards?](https://theponti.notion.site/Writing-great-software-9825f07e53e9481db997a6fbe70a4300)
- [x] [Is this change as small as possible?](https://theponti.notion.site/Make-Pull-Requests-Small-Again-7ea402269a06448a9ce62f5eebf0a238)
- [x] [Does this abide by pull request and commit conventions?](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] **Are these changes tested?**

## TODOs

### Before Merging
N/A

### After Merging
N/A