### PR TITLE
[PON-38] test: add GET list test

### DIFF
--- a/apps/api/src/plugins/lists/get/getLists.test.ts
+++ b/apps/api/src/plugins/lists/get/getLists.test.ts
@@ -1,0 +1,57 @@
+import { FastifyInstance } from "fastify";
+
+import { mockAuthSession } from "../../../test.utils";
+import { createServer } from "../../../server";
+
+describe("GET /lists/:id", () => {
+  let server: FastifyInstance;
+  // let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    server = await createServer({ logger: false });
+  });
+
+  afterEach(async () => {
+    jest.resetAllMocks();
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  test("returns 200", async () => {
+    const userList = {
+      list: {
+        accepted: false,
+        listId: "123",
+        invitedUserEmail: "test@email.com",
+        createdBy: {
+          email: "test@email.com",
+        },
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    };
+    const list = {
+      id: "123",
+      name: "test list",
+      createdBy: {
+        email: "test@email.com",
+      },
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    mockAuthSession();
+    (server.prisma.list.findMany as jest.Mock).mockResolvedValueOnce([list]);
+    (server.prisma.userLists.findMany as jest.Mock).mockResolvedValueOnce([
+      userList,
+    ]);
+    const response = await server.inject({
+      method: "GET",
+      url: `/lists`,
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual([list, userList.list]);
+  });
+});


### PR DESCRIPTION
## Ticket
https://linear.app/ponti/issue/PON-38

## Description

### What
This pull request adds a test for the GET /lists route.

### Why
This improves the team's assurance that the product is performing desirably.

### Resources
N/A

## Checklists

- [x] [Does this change abide by quality standards?](https://theponti.notion.site/Writing-great-software-9825f07e53e9481db997a6fbe70a4300)
- [x] [Is this change as small as possible?](https://theponti.notion.site/Make-Pull-Requests-Small-Again-7ea402269a06448a9ce62f5eebf0a238)
- [x] [Does this abide by pull request and commit conventions?](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] **Are these changes tested?**

## TODOs

### Before Merging
N/A

### After Merging
N/A
