### PR TITLE
[PON-69] feat: add cron to update imageUrls

### DIFF
--- a/apps/api/src/plugins/lists/crons/addPhotoToPlace.ts
+++ b/apps/api/src/plugins/lists/crons/addPhotoToPlace.ts
@@ -1,0 +1,42 @@
+// Fastify cron that uses the Google Places API to add a photo to all places in the database.
+
+import { FastifyInstance } from "fastify";
+import { prisma } from "../../prisma";
+import { getPlacePhoto } from "../../google-places";
+
+async function addPhotoToPlace(server: FastifyInstance) {
+  const places = await prisma.place.findMany();
+
+  if (!places.length) {
+    return;
+  }
+
+  for (const place of places) {
+    if (place.imageUrl) {
+      continue;
+    }
+
+    if (!place.googleMapsId) {
+      continue;
+    }
+
+    const photo = await getPlacePhoto(place.googleMapsId);
+
+    if (photo) {
+      await prisma.place.update({
+        where: { id: place.id },
+        data: { imageUrl: photo },
+      });
+    }
+  }
+
+  // Send email to admin
+  server.sendEmail(
+    process.env.SENDGRID_SENDER_EMAIL as string,
+    "All places have been updated with photos",
+    "All places have been updated with photos",
+    `<p>All places have been updated with photos</p>`,
+  );
+}
+
+export default addPhotoToPlace;

--- a/apps/api/src/plugins/lists/index.ts
+++ b/apps/api/src/plugins/lists/index.ts
@@ -10,6 +10,7 @@ import postListsPlace from "./post/place";
 import postListRoute from "./post";
 import acceptListInviteRoute from "./post/acceptInvite";
 import putListRoute from "./put";
+import addPhotoToPlace from "./crons/addPhotoToPlace";
 
 const listsPlugin: FastifyPluginAsync = async (server) => {
   acceptListInviteRoute(server);
@@ -20,6 +21,11 @@ const listsPlugin: FastifyPluginAsync = async (server) => {
   postListRoute(server);
   postListsPlace(server);
   putListRoute(server);
+
+  // Add cron jobs
+  addPhotoToPlace(server).catch((err) => {
+    server.log.error(err);
+  });
 };
 
 export default fastifyPlugin(listsPlugin);


### PR DESCRIPTION
## Ticket
https://linear.app/ponti/issue/pon-69

This pull request adds a cron to backfill the `imageUrl` of places saved before the product began saving imageUrls.

## TODOs

### Before Merging
N/A

### After Merging
N/A
