### PR TITLE
fix(ci): consolidate and unblock open PRs

### DIFF
--- a/.github/workflows/deploy-earth-prod.yml
+++ b/.github/workflows/deploy-earth-prod.yml
@@ -12,21 +12,11 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    env:
-      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-
-    steps:
-      - name: install-railway-cli
-        run: npm install -g @railway/cli@4.58.0
-
-      - name: checkout-code
-        uses: actions/checkout@v4
-
-      - name: validate-env
-        run: test -n "$RAILWAY_TOKEN"
-
-      - name: deploy-to-railway
-        run: railway up --service ${{ secrets.RAILWAY_SERVICE_EARTH_INTELLIGENCE }} --detach --ci
+    uses: ./.github/workflows/reusable-railway-deploy.yml
+    with:
+      node-version: '24'
+      railway-cli-version: '4.58.0'
+      timeout-minutes: 10
+    secrets:
+      railway_token: ${{ secrets.RAILWAY_TOKEN }}
+      railway_service: ${{ secrets.RAILWAY_SERVICE_EARTH_INTELLIGENCE }}

--- a/.github/workflows/deploy-earth-prod.yml
+++ b/.github/workflows/deploy-earth-prod.yml
@@ -14,6 +14,7 @@ jobs:
   deploy:
     uses: ./.github/workflows/reusable-railway-deploy.yml
     with:
+      config_path: apps/cartograph/railway.json
       node-version: '24'
       railway-cli-version: '4.58.0'
       timeout-minutes: 10

--- a/.github/workflows/deploy-health-prod.yml
+++ b/.github/workflows/deploy-health-prod.yml
@@ -14,6 +14,7 @@ jobs:
   deploy:
     uses: ./.github/workflows/reusable-railway-deploy.yml
     with:
+      config_path: apps/vitalis/railway.json
       node-version: '24'
       railway-cli-version: '4.58.0'
       timeout-minutes: 10

--- a/.github/workflows/deploy-health-prod.yml
+++ b/.github/workflows/deploy-health-prod.yml
@@ -12,21 +12,11 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    env:
-      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-
-    steps:
-      - name: install-railway-cli
-        run: npm install -g @railway/cli@4.58.0
-
-      - name: checkout-code
-        uses: actions/checkout@v4
-
-      - name: validate-env
-        run: test -n "$RAILWAY_TOKEN"
-
-      - name: deploy-to-railway
-        run: railway up --service ${{ secrets.RAILWAY_SERVICE_HEALTH }} --detach --ci
+    uses: ./.github/workflows/reusable-railway-deploy.yml
+    with:
+      node-version: '24'
+      railway-cli-version: '4.58.0'
+      timeout-minutes: 10
+    secrets:
+      railway_token: ${{ secrets.RAILWAY_TOKEN }}
+      railway_service: ${{ secrets.RAILWAY_SERVICE_HEALTH }}

--- a/.github/workflows/deploy-home-prod.yml
+++ b/.github/workflows/deploy-home-prod.yml
@@ -9,6 +9,7 @@ on:
       - 'package.json'
       - 'pnpm-lock.yaml'
       - '.github/workflows/deploy-home-prod.yml'
+      - '.github/workflows/reusable-railway-deploy.yml'
   workflow_dispatch:
 
 permissions:
@@ -20,21 +21,11 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    env:
-      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-
-    steps:
-      - name: install-railway-cli
-        run: npm install -g @railway/cli@4.58.0
-
-      - name: checkout-code
-        uses: actions/checkout@v4
-
-      - name: validate-env
-        run: test -n "$RAILWAY_TOKEN"
-
-      - name: deploy-to-railway
-        run: railway up --service ${{ secrets.RAILWAY_SERVICE_HOME }} --detach --ci
+    uses: ./.github/workflows/reusable-railway-deploy.yml
+    with:
+      node-version: '24'
+      railway-cli-version: '4.58.0'
+      timeout-minutes: 10
+    secrets:
+      railway_token: ${{ secrets.RAILWAY_TOKEN }}
+      railway_service: ${{ secrets.RAILWAY_SERVICE_HOME }}

--- a/.github/workflows/deploy-playground-prod.yml
+++ b/.github/workflows/deploy-playground-prod.yml
@@ -9,6 +9,7 @@ on:
       - 'package.json'
       - 'pnpm-lock.yaml'
       - '.github/workflows/deploy-playground-prod.yml'
+      - '.github/workflows/reusable-railway-deploy.yml'
   workflow_dispatch:
 
 permissions:
@@ -20,21 +21,11 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    env:
-      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-
-    steps:
-      - name: install-railway-cli
-        run: npm install -g @railway/cli@4.58.0
-
-      - name: checkout-code
-        uses: actions/checkout@v4
-
-      - name: validate-env
-        run: test -n "$RAILWAY_TOKEN"
-
-      - name: deploy-to-railway
-        run: railway up --service ${{ secrets.RAILWAY_SERVICE_PLAYGROUND }} --detach --ci
+    uses: ./.github/workflows/reusable-railway-deploy.yml
+    with:
+      node-version: '24'
+      railway-cli-version: '4.58.0'
+      timeout-minutes: 10
+    secrets:
+      railway_token: ${{ secrets.RAILWAY_TOKEN }}
+      railway_service: ${{ secrets.RAILWAY_SERVICE_PLAYGROUND }}

--- a/.github/workflows/deploy-playground-prod.yml
+++ b/.github/workflows/deploy-playground-prod.yml
@@ -23,6 +23,7 @@ jobs:
   deploy:
     uses: ./.github/workflows/reusable-railway-deploy.yml
     with:
+      config_path: apps/labyrinth/railway.json
       node-version: '24'
       railway-cli-version: '4.58.0'
       timeout-minutes: 10

--- a/.github/workflows/deploy-social-prod.yml
+++ b/.github/workflows/deploy-social-prod.yml
@@ -14,6 +14,7 @@ jobs:
   deploy:
     uses: ./.github/workflows/reusable-railway-deploy.yml
     with:
+      config_path: apps/commune/railway.json
       node-version: '24'
       railway-cli-version: '4.58.0'
       timeout-minutes: 10

--- a/.github/workflows/deploy-social-prod.yml
+++ b/.github/workflows/deploy-social-prod.yml
@@ -12,21 +12,11 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    env:
-      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-
-    steps:
-      - name: install-railway-cli
-        run: npm install -g @railway/cli@4.58.0
-
-      - name: checkout-code
-        uses: actions/checkout@v4
-
-      - name: validate-env
-        run: test -n "$RAILWAY_TOKEN"
-
-      - name: deploy-to-railway
-        run: railway up --service ${{ secrets.RAILWAY_SERVICE_SOCIAL }} --detach --ci
+    uses: ./.github/workflows/reusable-railway-deploy.yml
+    with:
+      node-version: '24'
+      railway-cli-version: '4.58.0'
+      timeout-minutes: 10
+    secrets:
+      railway_token: ${{ secrets.RAILWAY_TOKEN }}
+      railway_service: ${{ secrets.RAILWAY_SERVICE_SOCIAL }}

--- a/.github/workflows/reusable-railway-deploy.yml
+++ b/.github/workflows/reusable-railway-deploy.yml
@@ -1,0 +1,55 @@
+name: reusable-railway-deploy
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: Node.js version used to install Railway CLI
+        required: false
+        type: string
+        default: '24'
+      railway-cli-version:
+        description: Railway CLI version to install
+        required: false
+        type: string
+        default: '4.58.0'
+      timeout-minutes:
+        description: Job timeout in minutes
+        required: false
+        type: number
+        default: 10
+    secrets:
+      railway_token:
+        description: Railway API token
+        required: true
+      railway_service:
+        description: Railway service identifier
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    env:
+      RAILWAY_TOKEN: ${{ secrets.railway_token }}
+
+    steps:
+      - name: checkout-code
+        uses: actions/checkout@v4
+
+      - name: setup-node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: install-railway-cli
+        run: npm install -g @railway/cli@${{ inputs.railway-cli-version }}
+
+      - name: validate-env
+        run: test -n "$RAILWAY_TOKEN"
+
+      - name: deploy-to-railway
+        run: railway up --service ${{ secrets.railway_service }} --detach --ci

--- a/.github/workflows/reusable-railway-deploy.yml
+++ b/.github/workflows/reusable-railway-deploy.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
         default: '24'
+      config_path:
+        description: Optional path to a service-specific Railway config file
+        required: false
+        type: string
+        default: ''
       railway-cli-version:
         description: Railway CLI version to install
         required: false
@@ -50,6 +55,10 @@ jobs:
 
       - name: validate-env
         run: test -n "$RAILWAY_TOKEN"
+
+      - name: stage-railway-config
+        if: inputs.config_path != ''
+        run: cp "${{ inputs.config_path }}" railway.json
 
       - name: deploy-to-railway
         run: railway up --service ${{ secrets.railway_service }} --detach --ci

--- a/apps/labyrinth/Dockerfile
+++ b/apps/labyrinth/Dockerfile
@@ -9,8 +9,9 @@ RUN npm install -g pnpm@10.30.3
 
 WORKDIR /app
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
 COPY apps/labyrinth/package.json apps/labyrinth/package.json
+COPY packages/db/package.json packages/db/package.json
 COPY packages/ui/package.json packages/ui/package.json
 COPY packages/tsconfig/package.json packages/tsconfig/package.json
 
@@ -21,10 +22,13 @@ FROM deps AS builder
 
 WORKDIR /app
 
+COPY tsconfig.base.json ./
+COPY packages/db/ packages/db/
 COPY packages/tsconfig/ packages/tsconfig/
 COPY packages/ui/ packages/ui/
 COPY apps/labyrinth/ apps/labyrinth/
 
+RUN pnpm run build --filter @pontistudios/db
 RUN pnpm run build --filter @pontistudios/ui
 RUN pnpm run build --filter @pontistudios/labyrinth
 
@@ -38,11 +42,13 @@ WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/labyrinth/package.json apps/labyrinth/package.json
+COPY packages/db/package.json packages/db/package.json
 COPY packages/ui/package.json packages/ui/package.json
 COPY packages/tsconfig/package.json packages/tsconfig/package.json
 
 RUN pnpm install --frozen-lockfile --prod --ignore-scripts
 
+COPY --from=builder /app/packages/db/dist packages/db/dist
 COPY --from=builder /app/packages/ui/dist packages/ui/dist
 COPY --from=builder /app/apps/labyrinth/build apps/labyrinth/build
 

--- a/apps/labyrinth/app/components/terminal/__tests__/TerminalInput.test.tsx
+++ b/apps/labyrinth/app/components/terminal/__tests__/TerminalInput.test.tsx
@@ -3,18 +3,6 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { TerminalInput } from "../TerminalInput";
 
-// Mock the CSS module
-vi.mock("../../routes/home.module.css", () => ({
-  default: {
-    terminalLine: "terminalLine",
-    prompt: "prompt",
-    inputWrapper: "inputWrapper",
-    typedText: "typedText",
-    cursor: "cursor",
-    commandInput: "commandInput",
-  },
-}));
-
 describe("TerminalInput Component", () => {
   const mockOnCommandChange = vi.fn();
   const mockOnKeyDown = vi.fn();
@@ -31,7 +19,7 @@ describe("TerminalInput Component", () => {
   test("renders prompt and input correctly", () => {
     render(<TerminalInput {...defaultProps} />);
 
-    expect(screen.getByText("C:\\CHUCK>")).toBeInTheDocument();
+    expect(screen.getByText("$")).toBeInTheDocument();
     expect(screen.getByRole("textbox")).toBeInTheDocument();
   });
 
@@ -44,7 +32,7 @@ describe("TerminalInput Component", () => {
   test("shows cursor", () => {
     render(<TerminalInput {...defaultProps} currentCommand="test" />);
 
-    const cursor = screen.getByText("_");
+    const cursor = screen.getByText("▊");
     expect(cursor).toBeInTheDocument();
   });
 
@@ -97,10 +85,17 @@ describe("TerminalInput Component", () => {
   test("input is visually hidden but functional", () => {
     render(<TerminalInput {...defaultProps} />);
 
-    const input = screen.getByRole("textbox") as HTMLInputElement;
-    expect(input.style.position).toBe("absolute");
-    expect(input.style.left).toBe("-9999px");
-    expect(input.style.opacity).toBe("0");
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveClass(
+      "absolute",
+      "inset-0",
+      "w-full",
+      "bg-transparent",
+      "text-transparent",
+      "border-none",
+      "outline-none",
+      "caret-transparent",
+    );
   });
 
   test("handles special characters", async () => {

--- a/apps/labyrinth/app/components/terminal/__tests__/TerminalLine.test.tsx
+++ b/apps/labyrinth/app/components/terminal/__tests__/TerminalLine.test.tsx
@@ -3,17 +3,6 @@ import { describe, expect, test, vi } from "vitest";
 import { TerminalLine } from "../TerminalLine";
 import type { TerminalLine as TerminalLineType } from "../types";
 
-// Mock the CSS module
-vi.mock("../../routes/home.module.css", () => ({
-  default: {
-    terminalLine: "terminalLine",
-    command: "command",
-    output: "output",
-    error: "error",
-    systemInfo: "systemInfo",
-  },
-}));
-
 describe("TerminalLine Component", () => {
   test("renders command line correctly", () => {
     const line: TerminalLineType = {
@@ -68,7 +57,7 @@ describe("TerminalLine Component", () => {
     const { container } = render(<TerminalLine line={line} index={0} />);
     const element = container.firstChild as HTMLElement;
 
-    expect(element).toHaveClass("terminalLine", "command");
+    expect(element).toHaveClass("font-mono", "text-sm", "leading-relaxed", "text-olive-200", "font-medium");
   });
 
   test("applies correct CSS class for error type", () => {
@@ -80,7 +69,7 @@ describe("TerminalLine Component", () => {
     const { container } = render(<TerminalLine line={line} index={0} />);
     const element = container.firstChild as HTMLElement;
 
-    expect(element).toHaveClass("terminalLine", "error");
+    expect(element).toHaveClass("font-mono", "text-sm", "leading-relaxed", "text-red-300");
   });
 
   test("applies correct CSS class for system type", () => {
@@ -92,7 +81,7 @@ describe("TerminalLine Component", () => {
     const { container } = render(<TerminalLine line={line} index={0} />);
     const element = container.firstChild as HTMLElement;
 
-    expect(element).toHaveClass("terminalLine", "systemInfo");
+    expect(element).toHaveClass("font-mono", "text-sm", "leading-relaxed", "text-amber-300/90", "font-light");
   });
 
   test("applies correct CSS class for output type", () => {
@@ -104,7 +93,7 @@ describe("TerminalLine Component", () => {
     const { container } = render(<TerminalLine line={line} index={0} />);
     const element = container.firstChild as HTMLElement;
 
-    expect(element).toHaveClass("terminalLine", "output");
+    expect(element).toHaveClass("font-mono", "text-sm", "leading-relaxed", "text-stone-300");
   });
 
   test("handles empty content", () => {
@@ -125,9 +114,11 @@ describe("TerminalLine Component", () => {
       content: "  spaced   content  ",
     };
 
-    render(<TerminalLine line={line} index={0} />);
+    const { container } = render(<TerminalLine line={line} index={0} />);
+    const pre = container.querySelector("pre");
 
-    expect(screen.getByText("  spaced   content  ")).toBeInTheDocument();
+    expect(pre).toBeInTheDocument();
+    expect(pre?.textContent).toBe("  spaced   content  ");
   });
 
   test("handles multiline content", () => {

--- a/apps/labyrinth/app/components/terminal/__tests__/constants.test.ts
+++ b/apps/labyrinth/app/components/terminal/__tests__/constants.test.ts
@@ -30,13 +30,15 @@ describe("Terminal Constants", () => {
     test("ASCII_LOGO should be a non-empty string", () => {
       expect(typeof ASCII_LOGO).toBe("string");
       expect(ASCII_LOGO.trim()).toBeTruthy();
-      expect(ASCII_LOGO).toContain("CHUCK");
+      expect(ASCII_LOGO).toContain("██████");
+      expect(ASCII_LOGO.split("\n").filter(Boolean).length).toBeGreaterThan(5);
     });
 
     test("CYBER_SKULLS should be a non-empty string", () => {
       expect(typeof CYBER_SKULLS).toBe("string");
       expect(CYBER_SKULLS.trim()).toBeTruthy();
-      expect(CYBER_SKULLS).toContain("CYBER");
+      expect(CYBER_SKULLS).toContain("██████");
+      expect(CYBER_SKULLS.split("\n").filter(Boolean).length).toBeGreaterThan(5);
     });
 
     test("CAT_ASCII should contain cat parts", () => {

--- a/apps/labyrinth/app/components/terminal/__tests__/useCommandExecution.test.tsx
+++ b/apps/labyrinth/app/components/terminal/__tests__/useCommandExecution.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import type { TerminalLine } from "../types";
 import { useCommandExecution } from "../useCommandExecution";
@@ -33,31 +33,30 @@ const mockElement: MockElement = {
   },
 };
 
-Object.defineProperty(global, "document", {
-  value: {
-    querySelector: vi.fn(() => ({
-      className: "terminal",
-    })),
-    createElement: vi.fn(() => mockElement),
-    head: {
-      appendChild: vi.fn(),
-    },
-    body: {
-      appendChild: vi.fn(),
-    },
-  },
-  writable: true,
-});
-
 // Wrapper component for React Router context
 function RouterWrapper({ children }: { children: React.ReactNode }) {
   return <BrowserRouter>{children}</BrowserRouter>;
 }
 
+const renderUseCommandExecution = () =>
+  renderHook(() => useCommandExecution(), {
+    wrapper: RouterWrapper,
+  });
+
+const applySetLinesUpdate = (
+  setLinesMock: ReturnType<typeof vi.fn>,
+  callIndex: number,
+  previousLines: TerminalLine[] = [],
+) => {
+  const updater = setLinesMock.mock.calls[callIndex]?.[0];
+  return typeof updater === "function" ? updater(previousLines) : updater;
+};
+
 describe("useCommandExecution Hook", () => {
   let setLines: ReturnType<typeof vi.fn>;
   let setCommandHistory: ReturnType<typeof vi.fn>;
   let commandHistory: string[];
+  const originalCreateElement = document.createElement.bind(document);
 
   beforeEach(() => {
     setLines = vi.fn();
@@ -66,15 +65,27 @@ describe("useCommandExecution Hook", () => {
     mockNavigate.mockClear();
     vi.clearAllTimers();
     vi.useFakeTimers();
+    vi.spyOn(document, "querySelector").mockReturnValue({
+      className: "terminal",
+    } as Element);
+    vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+      if (tagName === "div" || tagName === "style") {
+        return originalCreateElement(tagName);
+      }
+
+      return mockElement as unknown as HTMLElement;
+    });
+    vi.spyOn(document.head, "appendChild").mockImplementation((node) => node);
+    vi.spyOn(document.body, "appendChild").mockImplementation((node) => node);
   });
 
   test("should return executeCommand function", () => {
-    const { result } = renderHook(() => useCommandExecution());
+    const { result } = renderUseCommandExecution();
     expect(typeof result.current.executeCommand).toBe("function");
   });
 
   test("executeCommand should add command to history", () => {
-    const { result } = renderHook(() => useCommandExecution());
+    const { result } = renderUseCommandExecution();
 
     act(() => {
       result.current.executeCommand("help", commandHistory, setLines, setCommandHistory);
@@ -84,7 +95,7 @@ describe("useCommandExecution Hook", () => {
   });
 
   test("executeCommand should handle help command", () => {
-    const { result } = renderHook(() => useCommandExecution());
+    const { result } = renderUseCommandExecution();
 
     act(() => {
       result.current.executeCommand("help", commandHistory, setLines, setCommandHistory);
@@ -93,11 +104,11 @@ describe("useCommandExecution Hook", () => {
     expect(setLines).toHaveBeenCalledWith(expect.any(Function));
 
     // Get the function passed to setLines and call it with empty array
-    const setLinesCall = setLines.mock.calls[0][0];
-    const newLines = setLinesCall([]);
+    const commandLines = applySetLinesUpdate(setLines, 0, []);
+    const newLines = applySetLinesUpdate(setLines, 1, commandLines);
 
     // Should contain command line and help content
-    expect(newLines[0]).toEqual({
+    expect(commandLines[0]).toEqual({
       type: "command",
       content: "C:\\CHUCK> help",
     });
@@ -108,7 +119,7 @@ describe("useCommandExecution Hook", () => {
   });
 
   test("executeCommand should handle cls command", () => {
-    const { result } = renderHook(() => useCommandExecution());
+    const { result } = renderUseCommandExecution();
 
     act(() => {
       result.current.executeCommand("cls", commandHistory, setLines, setCommandHistory);
@@ -123,14 +134,14 @@ describe("useCommandExecution Hook", () => {
   });
 
   test("executeCommand should handle gradient command and navigate", () => {
-    const { result } = renderHook(() => useCommandExecution());
+    const { result } = renderUseCommandExecution();
 
     act(() => {
       result.current.executeCommand("gradient", commandHistory, setLines, setCommandHistory);
     });
 
-    const setLinesCall = setLines.mock.calls[0][0];
-    const newLines = setLinesCall([]);
+    const commandLines = applySetLinesUpdate(setLines, 0, []);
+    const newLines = applySetLinesUpdate(setLines, 1, commandLines);
 
     expect(
       newLines.some((line: TerminalLine) =>
@@ -147,14 +158,14 @@ describe("useCommandExecution Hook", () => {
   });
 
   test("executeCommand should handle meow command", () => {
-    const { result } = renderHook(() => useCommandExecution());
+    const { result } = renderUseCommandExecution();
 
     act(() => {
       result.current.executeCommand("meow", commandHistory, setLines, setCommandHistory);
     });
 
-    const setLinesCall = setLines.mock.calls[0][0];
-    const newLines = setLinesCall([]);
+    const commandLines = applySetLinesUpdate(setLines, 0, []);
+    const newLines = applySetLinesUpdate(setLines, 1, commandLines);
 
     expect(
       newLines.some((line: TerminalLine) => line.content.includes("Summoning cyber cats")),
@@ -169,14 +180,14 @@ describe("useCommandExecution Hook", () => {
   });
 
   test("executeCommand should handle unknown command", () => {
-    const { result } = renderHook(() => useCommandExecution());
+    const { result } = renderUseCommandExecution();
 
     act(() => {
       result.current.executeCommand("unknown", commandHistory, setLines, setCommandHistory);
     });
 
-    const setLinesCall = setLines.mock.calls[0][0];
-    const newLines = setLinesCall([]);
+    const commandLines = applySetLinesUpdate(setLines, 0, []);
+    const newLines = applySetLinesUpdate(setLines, 1, commandLines);
 
     expect(
       newLines.some((line: TerminalLine) => line.content.includes("Bad command or file name")),
@@ -184,7 +195,7 @@ describe("useCommandExecution Hook", () => {
   });
 
   test("should not add duplicate commands to history", () => {
-    const { result } = renderHook(() => useCommandExecution());
+    const { result } = renderUseCommandExecution();
     const existingHistory = ["help"];
 
     act(() => {

--- a/apps/labyrinth/app/routes/Cards.jsx
+++ b/apps/labyrinth/app/routes/Cards.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { createDeck } from './cards-lib'
+import { createDeck } from './cards-lib.ts'
 
 export default function Cards() {
   const [deck, setDeck] = useState(() => createDeck())

--- a/apps/labyrinth/app/routes/__tests__/border-linear-gradient.test.ts
+++ b/apps/labyrinth/app/routes/__tests__/border-linear-gradient.test.ts
@@ -4,7 +4,7 @@ import {
   defaultSettings,
   encodeSettings,
   type GradientSettings,
-} from "~/lib/gradient";
+} from "../../lib/gradient";
 
 // Mock console methods to avoid noise in tests
 beforeEach(() => {

--- a/apps/labyrinth/app/routes/__tests__/tasks.test.tsx
+++ b/apps/labyrinth/app/routes/__tests__/tasks.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import TasksByProject from "../tasks.$projectId";
 
 // Mock the hooks
-vi.mock("~/lib/todos", () => ({
+vi.mock("../../lib/todos", () => ({
   useTodos: vi.fn(),
   useDeleteTodo: vi.fn(() => ({
     mutate: vi.fn(),
@@ -12,15 +12,15 @@ vi.mock("~/lib/todos", () => ({
   })),
 }));
 
-vi.mock("~/lib/projects", () => ({
+vi.mock("../../lib/projects", () => ({
   useProjects: vi.fn(),
 }));
 
-vi.mock("~/components/to-do/TaskForm", () => ({
+vi.mock("../../components/to-do/TaskForm", () => ({
   default: () => <div data-testid="task-form">Task Form</div>,
 }));
 
-vi.mock("~/components/to-do/TaskList", () => ({
+vi.mock("../../components/to-do/TaskList", () => ({
   TaskList: ({ todos }: { todos: any[] }) => (
     <div data-testid="task-list">
       {todos.map((todo) => (
@@ -95,8 +95,8 @@ describe("TasksByProject", () => {
   });
 
   it("should render tasks filtered by project", async () => {
-    const { useTodos } = await import("~/lib/todos");
-    const { useProjects } = await import("~/lib/projects");
+    const { useTodos } = await import("../../lib/todos");
+    const { useProjects } = await import("../../lib/projects");
 
     vi.mocked(useTodos).mockReturnValue({
       data: mockTodos,
@@ -143,8 +143,8 @@ describe("TasksByProject", () => {
   });
 
   it("should show loading state", async () => {
-    const { useTodos } = await import("~/lib/todos");
-    const { useProjects } = await import("~/lib/projects");
+    const { useTodos } = await import("../../lib/todos");
+    const { useProjects } = await import("../../lib/projects");
 
     vi.mocked(useTodos).mockReturnValue({
       data: [],
@@ -176,8 +176,8 @@ describe("TasksByProject", () => {
   });
 
   it("should show error state", async () => {
-    const { useTodos } = await import("~/lib/todos");
-    const { useProjects } = await import("~/lib/projects");
+    const { useTodos } = await import("../../lib/todos");
+    const { useProjects } = await import("../../lib/projects");
 
     vi.mocked(useTodos).mockReturnValue({
       data: [],
@@ -209,8 +209,8 @@ describe("TasksByProject", () => {
   });
 
   it("should show project not found when project doesn't exist", async () => {
-    const { useTodos } = await import("~/lib/todos");
-    const { useProjects } = await import("~/lib/projects");
+    const { useTodos } = await import("../../lib/todos");
+    const { useProjects } = await import("../../lib/projects");
 
     vi.mocked(useTodos).mockReturnValue({
       data: mockTodos,

--- a/apps/labyrinth/app/routes/cards-lib.ts
+++ b/apps/labyrinth/app/routes/cards-lib.ts
@@ -1,0 +1,71 @@
+const RANKS = ['2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K', 'A']
+const SUITS = ['Hearts', 'Diamonds', 'Clubs', 'Spades']
+
+function getSuit(suit) {
+  switch (suit) {
+    case 'H': return '♥'
+    case 'D': return '♦'
+    case 'C': return '♣'
+    case 'S': return '♠'
+    default: return suit
+  }
+}
+
+function getRank(rank) {
+  return rank
+}
+
+class Card {
+  id
+  suit
+  rank
+  value
+
+  constructor(suit, rank) {
+    this.id = `${suit} ${rank}`
+    this.suit = getSuit(suit)
+    this.rank = getRank(rank)
+    this.value = SUITS.indexOf(suit) + RANKS.indexOf(rank) + 2
+  }
+}
+
+class Deck {
+  cards = []
+
+  constructor() {
+    this.cards = []
+    for (const suit of SUITS.map((_, i) => ['H', 'D', 'C', 'S'][i])) {
+      for (const rank of RANKS) {
+        this.cards.push(new Card(suit, rank))
+      }
+    }
+    this.shuffle()
+  }
+
+  shuffle() {
+    for (let i = this.cards.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1))
+      ;[this.cards[i], this.cards[j]] = [this.cards[j], this.cards[i]]
+    }
+  }
+
+  deal() {
+    return this.cards.pop()
+  }
+}
+
+function createDeck() {
+  const deck = []
+  for (const suit of ['H', 'D', 'C', 'S']) {
+    for (const rank of RANKS) {
+      deck.push(new Card(suit, rank))
+    }
+  }
+  for (let i = deck.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[deck[i], deck[j]] = [deck[j], deck[i]]
+  }
+  return deck
+}
+
+export { Card, Deck, RANKS, SUITS, createDeck }

--- a/apps/tempo/package.json
+++ b/apps/tempo/package.json
@@ -22,6 +22,7 @@
     "@tailwindcss/vite": "catalog:",
     "@testing-library/jest-dom": "catalog:",
     "@vitejs/plugin-react": "catalog:",
+    "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "dotenv": "^17.4.2",
     "framer-motion": "^12.38.0",

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -29,5 +29,6 @@ export default defineConfig({
       },
     },
     sourcemap: true,
+    target: "esnext",
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -463,6 +463,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.12(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0


### PR DESCRIPTION
## Summary
- fix the shared UI build regression by targeting `esnext` in the UI library build
- add the missing `clsx` dependency in Tempo and refresh the lockfile
- update stale Labyrinth tests to match the current terminal and route modules
- absorb the Railway workflow improvements from #104 and restore the typed card deck helper

## Validation
- `pnpm audit --audit-level=high`
- `pnpm test`
- `pnpm run build`
- `pnpm run lint` (warnings only in pre-existing files outside this diff)

Supersedes the current stale dependency/update PR queue and folds in the remaining real workflow fixes from #104.
