### PR TITLE
feat(ui): elevate 18 finance-app components ahead of finance shutdown

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ponti-studios/ui",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "private": false,
   "description": "Shared UI component library for ponti-studios labs",
   "license": "UNLICENSED",

--- a/packages/ui/src/components/data-display/index.ts
+++ b/packages/ui/src/components/data-display/index.ts
@@ -1,6 +1,11 @@
 export { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "./accordion";
 export { FilterChip } from "./filter-chip";
 export type { FilterChipProps } from "./filter-chip";
+export { MetricCard } from "./metric-card";
+export { SortControls } from "./sort-controls";
+export type { SortControlsProps } from "./sort-controls";
+export { SortRow } from "./sort-row";
+export type { SortRowProps } from "./sort-row";
 export {
   Table,
   TableBody,

--- a/packages/ui/src/components/data-display/metric-card.stories.tsx
+++ b/packages/ui/src/components/data-display/metric-card.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { MetricCard } from "./metric-card";
+
+const meta = {
+  title: "DataDisplay/MetricCard",
+  component: MetricCard,
+  tags: ["autodocs"],
+} satisfies Meta<typeof MetricCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    label: "Net worth",
+    value: "$48,210",
+  },
+};
+
+export const WithChange: Story = {
+  args: {
+    label: "Monthly spend",
+    value: "$3,120",
+    change: "+4.2% vs last month",
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    label: "Runway",
+    value: undefined,
+  },
+};
+
+export const Grid: Story = {
+  args: {
+    label: "Net worth",
+    value: "$48,210",
+  },
+  render: () => (
+    <div className="grid w-[520px] grid-cols-3 gap-3">
+      <MetricCard label="Net worth" value="$48,210" change="+2.1%" />
+      <MetricCard label="Income" value="$6,400" />
+      <MetricCard label="Expenses" value="$3,120" change="-1.4%" />
+    </div>
+  ),
+};

--- a/packages/ui/src/components/data-display/metric-card.tsx
+++ b/packages/ui/src/components/data-display/metric-card.tsx
@@ -1,0 +1,20 @@
+import type { ComponentProps, ReactNode } from "react";
+
+import { cn } from "../../lib/utils";
+
+interface MetricCardProps extends ComponentProps<"div"> {
+  label: string;
+  value: ReactNode;
+  change?: ReactNode;
+}
+
+/** Label/value/change stat tile. */
+export function MetricCard({ label, value, change, className, ...props }: MetricCardProps) {
+  return (
+    <div className={cn("ui-flat-card", className)} {...props}>
+      <p className="ui-data-label mb-2">{label}</p>
+      <p className="ui-data-value">{value ?? "—"}</p>
+      {change != null ? <p className="text-muted-foreground mt-1.5 text-xs">{change}</p> : null}
+    </div>
+  );
+}

--- a/packages/ui/src/components/data-display/sort-controls.stories.tsx
+++ b/packages/ui/src/components/data-display/sort-controls.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+import type { SortOption } from "../../hooks/sort.types";
+import { SortControls } from "./sort-controls";
+
+const meta = {
+  title: "DataDisplay/SortControls",
+  component: SortControls,
+  tags: ["autodocs"],
+} satisfies Meta<typeof SortControls>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const sortableFields = ["amount", "date", "description", "category"];
+
+function SortControlsPreview() {
+  const [sortOptions, setSortOptions] = useState<SortOption[]>([
+    { field: "date", direction: "desc" },
+  ]);
+
+  return (
+    <SortControls
+      sortOptions={sortOptions}
+      sortableFields={sortableFields}
+      addSortOption={(option) => setSortOptions((prev) => [...prev, option])}
+      updateSortOption={(index, option) =>
+        setSortOptions((prev) => prev.map((o, i) => (i === index ? option : o)))
+      }
+      removeSortOption={(index) => setSortOptions((prev) => prev.filter((_, i) => i !== index))}
+    />
+  );
+}
+
+export const Default: Story = {
+  args: {
+    sortOptions: [],
+    sortableFields,
+    addSortOption: () => {},
+    updateSortOption: () => {},
+    removeSortOption: () => {},
+  },
+  render: () => <SortControlsPreview />,
+};

--- a/packages/ui/src/components/data-display/sort-controls.tsx
+++ b/packages/ui/src/components/data-display/sort-controls.tsx
@@ -1,0 +1,99 @@
+import { ListOrdered, PlusCircle } from "lucide-react";
+
+import type { SortField, SortOption } from "../../hooks/sort.types";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "../overlays/dropdown-menu";
+import { Button } from "../primitives/button";
+import { SortRow } from "./sort-row";
+
+export interface SortControlsProps {
+  sortOptions: SortOption[];
+  sortableFields: SortField[];
+  addSortOption: (option: SortOption) => void;
+  updateSortOption: (index: number, option: SortOption) => void;
+  removeSortOption: (index: number) => void;
+  open?: boolean | undefined;
+  onOpenChange?: ((open: boolean) => void) | undefined;
+  focusedSortIndex?: (number | null) | undefined;
+}
+
+/** Multi-field sort builder, driven by the `SortOption`/`SortField` shared types. */
+export function SortControls({
+  sortOptions,
+  sortableFields,
+  addSortOption,
+  updateSortOption,
+  removeSortOption,
+  open,
+  onOpenChange,
+  focusedSortIndex,
+}: SortControlsProps) {
+  const availableFieldsToAdd = sortableFields.filter(
+    (field) => !sortOptions.some((option) => option.field === field),
+  );
+
+  return (
+    <DropdownMenu {...(open !== undefined && { open })} {...(onOpenChange && { onOpenChange })}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">
+          <ListOrdered className="mr-2 size-4" />
+          Sort
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-80 space-y-2 p-2">
+        <DropdownMenuLabel>Define Sort Order</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+
+        <DropdownMenuGroup className="space-y-1">
+          {sortOptions.map((sort, index) => {
+            const usedFields = sortOptions
+              .filter((_, i) => i !== index)
+              .map((option) => option.field);
+            return (
+              <DropdownMenuItem
+                key={sort.field}
+                onSelect={(e) => e.preventDefault()}
+                className={`p-0 focus:bg-transparent ${index === focusedSortIndex ? "bg-accent" : ""}`}
+              >
+                <SortRow
+                  sortOption={sort}
+                  index={index}
+                  sortableFields={sortableFields}
+                  usedFields={usedFields}
+                  updateSortOption={updateSortOption}
+                  removeSortOption={removeSortOption}
+                />
+              </DropdownMenuItem>
+            );
+          })}
+        </DropdownMenuGroup>
+        {availableFieldsToAdd.length > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onSelect={(e) => {
+                e.preventDefault();
+                const firstAvailable = availableFieldsToAdd[0];
+                if (firstAvailable) {
+                  addSortOption({ field: firstAvailable, direction: "desc" });
+                }
+              }}
+              disabled={availableFieldsToAdd.length === 0}
+              className="mt-1"
+            >
+              <PlusCircle className="mr-2 size-4" />
+              Add Sort Criterion
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/ui/src/components/data-display/sort-row.tsx
+++ b/packages/ui/src/components/data-display/sort-row.tsx
@@ -1,0 +1,74 @@
+import type { SortField, SortOption } from "../../hooks/sort.types";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../forms/select";
+import { Button } from "../primitives/button";
+import { X } from "lucide-react";
+
+export interface SortRowProps {
+  sortOption: SortOption;
+  index: number;
+  sortableFields: SortField[];
+  usedFields: SortField[];
+  updateSortOption: (index: number, option: SortOption) => void;
+  removeSortOption: (index: number) => void;
+}
+
+export function SortRow({
+  sortOption,
+  index,
+  sortableFields,
+  usedFields,
+  updateSortOption,
+  removeSortOption,
+}: SortRowProps) {
+  const availableFieldsForCurrentSelect = sortableFields.filter(
+    (field) => !usedFields.includes(field) || field === sortOption.field,
+  );
+
+  return (
+    <div key={sortOption.field} className="flex items-center gap-2">
+      <Select
+        value={sortOption.field}
+        onValueChange={(value) => updateSortOption(index, { ...sortOption, field: value })}
+      >
+        <SelectTrigger className="h-8 w-[130px] text-xs">
+          <SelectValue placeholder="Select field" />
+        </SelectTrigger>
+        <SelectContent>
+          {availableFieldsForCurrentSelect.map((field) => (
+            <SelectItem key={field} value={field} className="text-xs">
+              {field.charAt(0).toUpperCase() + field.slice(1)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Select
+        value={sortOption.direction}
+        onValueChange={(value) => {
+          if (value === "asc" || value === "desc") {
+            updateSortOption(index, { ...sortOption, direction: value });
+          }
+        }}
+      >
+        <SelectTrigger className="h-8 w-[110px] text-xs">
+          <SelectValue placeholder="Direction" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="asc" className="text-xs">
+            Ascending
+          </SelectItem>
+          <SelectItem value="desc" className="text-xs">
+            Descending
+          </SelectItem>
+        </SelectContent>
+      </Select>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => removeSortOption(index)}
+        className="size-8 p-0"
+      >
+        <X className="text-muted-foreground size-4" />
+      </Button>
+    </div>
+  );
+}

--- a/packages/ui/src/components/feedback/file-upload-status-badge.stories.tsx
+++ b/packages/ui/src/components/feedback/file-upload-status-badge.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { FileUploadStatusBadge } from "./file-upload-status-badge";
+
+const meta = {
+  title: "Feedback/FileUploadStatusBadge",
+  component: FileUploadStatusBadge,
+  tags: ["autodocs"],
+} satisfies Meta<typeof FileUploadStatusBadge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { status: "uploading" },
+};
+
+export const AllStatuses: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <FileUploadStatusBadge status="uploading" />
+      <FileUploadStatusBadge status="processing" />
+      <FileUploadStatusBadge status="queued" />
+      <FileUploadStatusBadge status="done" />
+      <FileUploadStatusBadge status="error" />
+    </div>
+  ),
+};

--- a/packages/ui/src/components/feedback/file-upload-status-badge.tsx
+++ b/packages/ui/src/components/feedback/file-upload-status-badge.tsx
@@ -1,0 +1,33 @@
+import { memo } from "react";
+
+import { cn } from "../../lib/utils";
+
+export type FileUploadStatusValue = "uploading" | "processing" | "queued" | "done" | "error";
+
+const STATUS_CONFIG: Record<FileUploadStatusValue, { bg: string; text: string; label: string }> = {
+  uploading: { bg: "bg-muted", text: "text-foreground", label: "Uploading" },
+  processing: { bg: "bg-muted", text: "text-foreground", label: "Processing" },
+  queued: { bg: "bg-secondary", text: "text-secondary-foreground", label: "Queued" },
+  done: { bg: "bg-accent", text: "text-accent-foreground", label: "Complete" },
+  error: { bg: "bg-destructive/10", text: "text-destructive", label: "Error" },
+};
+
+export const FileUploadStatusBadge = memo(function FileUploadStatusBadge({
+  status,
+}: {
+  status?: string | undefined;
+}) {
+  if (!status) return null;
+
+  const config = STATUS_CONFIG[status as FileUploadStatusValue] ?? {
+    bg: "bg-muted",
+    text: "text-foreground",
+    label: status,
+  };
+
+  return (
+    <span className={cn("px-2 py-1 text-xs font-medium", config.bg, config.text)}>
+      {config.label}
+    </span>
+  );
+});

--- a/packages/ui/src/components/feedback/file-upload-status.stories.tsx
+++ b/packages/ui/src/components/feedback/file-upload-status.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { FileUploadStatus } from "./file-upload-status";
+
+const meta = {
+  title: "Feedback/FileUploadStatus",
+  component: FileUploadStatus,
+  tags: ["autodocs"],
+} satisfies Meta<typeof FileUploadStatus>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Uploading: Story = {
+  render: () => (
+    <div className="w-80">
+      <FileUploadStatus uploadStatus={{ status: "uploading", stats: { progress: 42 } }} />
+    </div>
+  ),
+};
+
+export const Queued: Story = {
+  render: () => (
+    <div className="w-80">
+      <FileUploadStatus uploadStatus={{ status: "queued" }} />
+    </div>
+  ),
+};
+
+export const Done: Story = {
+  render: () => (
+    <div className="w-80">
+      <FileUploadStatus
+        uploadStatus={{
+          status: "done",
+          stats: {
+            processingTime: 4200,
+            total: 128,
+            created: 90,
+            updated: 30,
+            skipped: 8,
+          },
+        }}
+      />
+    </div>
+  ),
+};
+
+export const Error: Story = {
+  render: () => (
+    <div className="w-80">
+      <FileUploadStatus
+        uploadStatus={{ status: "error", error: "Could not parse the CSV file." }}
+      />
+    </div>
+  ),
+};

--- a/packages/ui/src/components/feedback/file-upload-status.tsx
+++ b/packages/ui/src/components/feedback/file-upload-status.tsx
@@ -1,0 +1,154 @@
+import { XIcon } from "lucide-react";
+import { memo } from "react";
+
+import { cn } from "../../lib/utils";
+import { ProgressBar } from "./progress-bar";
+
+export interface FileUploadStats {
+  progress?: number;
+  processingTime?: number;
+  total?: number;
+  created?: number;
+  updated?: number;
+  skipped?: number;
+  merged?: number;
+  invalid?: number;
+  errors?: unknown[];
+}
+
+export interface FileUploadState {
+  status: "uploading" | "processing" | "queued" | "done" | "error" | (string & {});
+  error?: string;
+  stats?: FileUploadStats;
+}
+
+export const FileUploadStatus = memo(function FileUploadStatus({
+  uploadStatus,
+}: {
+  uploadStatus?: FileUploadState;
+}) {
+  if (!uploadStatus) return null;
+  const { status, error, stats } = uploadStatus;
+
+  if (status === "uploading" || status === "processing") {
+    const progress = stats?.progress;
+
+    return (
+      <output className="w-full">
+        <div className="mb-1.5 flex items-center justify-between">
+          <span className="text-muted-foreground text-sm font-medium">
+            {status === "uploading" ? "Uploading" : "Processing"}
+          </span>
+          <span className="text-foreground text-sm font-medium">
+            {progress !== undefined ? `${Math.round(progress)}%` : ""}
+          </span>
+        </div>
+        <div className="w-full">
+          {typeof progress === "number" ? (
+            <ProgressBar
+              progress={progress}
+              className={cn("bg-muted h-2", "before:bg-emphasis-high")}
+            />
+          ) : (
+            <div className="bg-muted h-2 overflow-hidden">
+              <div className="bg-emphasis-high void-anim-breezy-progress h-full" />
+            </div>
+          )}
+        </div>
+      </output>
+    );
+  }
+
+  if (status === "queued") {
+    return (
+      <output className="w-full">
+        <div className="mb-1.5 flex items-center justify-between">
+          <span className="text-muted-foreground text-sm font-medium">Queue position</span>
+        </div>
+        <div className="w-full">
+          <ProgressBar progress={0} className="bg-warning-subtle before:bg-warning h-2" />
+        </div>
+      </output>
+    );
+  }
+
+  if (status === "done") {
+    return (
+      <output className="space-y-3">
+        <div className="w-full">
+          <ProgressBar progress={100} className="bg-emphasis-minimal before:bg-emphasis-high h-2" />
+        </div>
+        {stats && <ProcessingStats stats={stats} />}
+      </output>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <output className="mt-2" role="alert">
+        <div className="bg-destructive/10 text-destructive flex items-start gap-2 p-3">
+          <XIcon className="mt-0.5 h-5 w-5 flex-shrink-0" aria-hidden="true" />
+          <span className="text-sm">{error}</span>
+        </div>
+      </output>
+    );
+  }
+
+  return <output className="text-muted-foreground text-sm">{status}</output>;
+});
+
+const ProcessingStats = memo(function ProcessingStats({ stats }: { stats: FileUploadStats }) {
+  if (!stats || typeof stats !== "object") return null;
+
+  return (
+    <dl className="divide-border mt-3 divide-y">
+      {stats.processingTime !== undefined && (
+        <div className="py-2 first:pt-0 last:pb-0">
+          <dt className="sr-only">Processing time</dt>
+          <dd className="text-foreground text-sm font-medium">
+            Completed in {(stats.processingTime / 1000).toFixed(1)}s
+          </dd>
+        </div>
+      )}
+      {stats.total !== undefined && Object.values(stats).length ? (
+        <div className="py-2">
+          <div className="grid grid-cols-2 gap-4">
+            <ProcessingStat label="Total" value={stats.total} />
+            <ProcessingStat label="Created" value={stats.created} />
+            <ProcessingStat label="Updated" value={stats.updated} />
+            <ProcessingStat label="Skipped" value={stats.skipped} />
+            <ProcessingStat label="Merged" value={stats.merged} />
+            <ProcessingStat label="Invalid" value={stats.invalid} />
+          </div>
+        </div>
+      ) : null}
+
+      {stats.errors?.length && stats.errors.length > 0 ? (
+        <div className="py-2">
+          <dt className="text-foreground text-sm font-medium">Errors</dt>
+          <dd className="mt-1">
+            <span className="bg-destructive/10 text-destructive inline-flex items-center px-2 py-1 text-xs font-medium">
+              {stats.errors.length} error{stats.errors.length > 1 ? "s" : ""}
+            </span>
+          </dd>
+        </div>
+      ) : null}
+    </dl>
+  );
+});
+
+const ProcessingStat = memo(function ProcessingStat({
+  label,
+  value,
+}: {
+  label: string;
+  value?: number | undefined;
+}) {
+  if (value === undefined) return null;
+  return (
+    <div>
+      <dt className="text-muted-foreground text-sm font-medium">{label}</dt>
+      <dd className="text-foreground mt-1 text-sm">{value.toLocaleString()}</dd>
+    </div>
+  );
+});

--- a/packages/ui/src/components/feedback/index.ts
+++ b/packages/ui/src/components/feedback/index.ts
@@ -1,6 +1,15 @@
 export { Alert, AlertDescription, AlertTitle } from "./alert";
 export { EmptyState } from "./empty-state";
 export type { EmptyStateProps } from "./empty-state";
+export { FileUploadStatus } from "./file-upload-status";
+export type { FileUploadState, FileUploadStats } from "./file-upload-status";
+export { FileUploadStatusBadge } from "./file-upload-status-badge";
+export type { FileUploadStatusValue } from "./file-upload-status-badge";
 export { Progress } from "./progress";
+export { ProgressBar } from "./progress-bar";
+export type { ProgressBarProps } from "./progress-bar";
+export { Skeleton } from "./skeleton";
 export { Spinner } from "./spinner";
 export type { SpinnerProps } from "./spinner";
+export { UpdateGuard } from "./update-guard";
+export type { UpdateGuardCopy, UpdateGuardProps } from "./update-guard";

--- a/packages/ui/src/components/feedback/progress-bar.stories.tsx
+++ b/packages/ui/src/components/feedback/progress-bar.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ProgressBar } from "./progress-bar";
+
+const meta = {
+  title: "Feedback/ProgressBar",
+  component: ProgressBar,
+  tags: ["autodocs"],
+} satisfies Meta<typeof ProgressBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { progress: 60 },
+  render: (args) => (
+    <div className="w-64">
+      <ProgressBar {...args} />
+    </div>
+  ),
+};
+
+export const Empty: Story = {
+  args: { progress: 0 },
+  render: (args) => (
+    <div className="w-64">
+      <ProgressBar {...args} />
+    </div>
+  ),
+};
+
+export const Complete: Story = {
+  args: { progress: 100 },
+  render: (args) => (
+    <div className="w-64">
+      <ProgressBar {...args} />
+    </div>
+  ),
+};

--- a/packages/ui/src/components/feedback/progress-bar.tsx
+++ b/packages/ui/src/components/feedback/progress-bar.tsx
@@ -1,0 +1,21 @@
+import { cn } from "../../lib/utils";
+
+export interface ProgressBarProps {
+  className?: string;
+  progress?: number;
+}
+
+/** Thin linear progress indicator, distinct from the Radix-backed `Progress`. */
+export function ProgressBar({ className, progress = 0 }: ProgressBarProps) {
+  return (
+    <div className={cn("border-border h-[2px] w-full overflow-hidden border-t", className)}>
+      <div
+        className={cn("border-warning h-full border-t")}
+        style={{
+          width: `${Math.min(100, Math.max(0, progress))}%`,
+          opacity: progress === 100 ? 0 : 0.8,
+        }}
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/components/feedback/skeleton.stories.tsx
+++ b/packages/ui/src/components/feedback/skeleton.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Skeleton } from "./skeleton";
+
+const meta = {
+  title: "Feedback/Skeleton",
+  component: Skeleton,
+  tags: ["autodocs"],
+} satisfies Meta<typeof Skeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => <Skeleton className="h-4 w-48" />,
+};
+
+export const TextLines: Story = {
+  render: () => (
+    <div className="w-64 space-y-2">
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-5/6" />
+      <Skeleton className="h-4 w-2/3" />
+    </div>
+  ),
+};
+
+export const CardShape: Story = {
+  render: () => (
+    <div className="w-64 space-y-3">
+      <Skeleton className="h-32 w-full" />
+      <Skeleton className="h-4 w-3/4" />
+      <Skeleton className="h-4 w-1/2" />
+    </div>
+  ),
+};

--- a/packages/ui/src/components/feedback/skeleton.tsx
+++ b/packages/ui/src/components/feedback/skeleton.tsx
@@ -1,0 +1,7 @@
+import type { ComponentProps } from "react";
+
+import { cn } from "../../lib/utils";
+
+export function Skeleton({ className, ...props }: ComponentProps<"div">) {
+  return <div className={cn("bg-muted animate-pulse rounded-md", className)} {...props} />;
+}

--- a/packages/ui/src/components/feedback/update-guard.stories.tsx
+++ b/packages/ui/src/components/feedback/update-guard.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { UpdateGuard } from "./update-guard";
+
+const meta = {
+  title: "Feedback/UpdateGuard",
+  component: UpdateGuard,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Registers a service worker at `serviceWorkerPath` and surfaces offline/update-available prompts. In Storybook there is no service worker to register against, so the prompts stay hidden — this story documents the wrapper's pass-through behavior for `children`.",
+      },
+    },
+  },
+} satisfies Meta<typeof UpdateGuard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    hideInDev: false,
+    children: (
+      <div className="border-border bg-surface text-muted-foreground rounded-md border p-6 text-sm">
+        App content renders here. Offline/update prompts appear fixed to the bottom of the viewport
+        when the service worker reports a change.
+      </div>
+    ),
+  },
+};

--- a/packages/ui/src/components/feedback/update-guard.tsx
+++ b/packages/ui/src/components/feedback/update-guard.tsx
@@ -1,0 +1,280 @@
+import type { ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+
+interface RegisterSWOptions {
+  onRegistered?: (registration: ServiceWorkerRegistration | undefined) => void;
+  onRegisterError?: (error: Error) => void;
+  serviceWorkerPath?: string;
+}
+
+interface RegisterSWResult {
+  offlineReady: [boolean, (value: boolean) => void];
+  needRefresh: [boolean, (value: boolean) => void];
+  updateServiceWorker: (reload?: boolean) => void;
+}
+
+function useRegisterSW(options?: RegisterSWOptions): RegisterSWResult {
+  const [offlineReady, setOfflineReady] = useState(false);
+  const [needRefresh, setNeedRefresh] = useState(false);
+  const registrationRef = useRef<ServiceWorkerRegistration | undefined>(undefined);
+  const shouldReloadRef = useRef(false);
+  const hasReloadedRef = useRef(false);
+  const onRegisteredRef = useRef(options?.onRegistered);
+  const onRegisterErrorRef = useRef(options?.onRegisterError);
+  const serviceWorkerPathRef = useRef(options?.serviceWorkerPath ?? "/sw.js");
+
+  useEffect(() => {
+    onRegisteredRef.current = options?.onRegistered;
+    onRegisterErrorRef.current = options?.onRegisterError;
+    serviceWorkerPathRef.current = options?.serviceWorkerPath ?? "/sw.js";
+  }, [options?.onRegistered, options?.onRegisterError, options?.serviceWorkerPath]);
+
+  useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      !("serviceWorker" in navigator) ||
+      !window.isSecureContext
+    ) {
+      return;
+    }
+
+    let isMounted = true;
+
+    const handleControllerChange = () => {
+      if (!shouldReloadRef.current || hasReloadedRef.current) {
+        return;
+      }
+
+      hasReloadedRef.current = true;
+      window.location.reload();
+    };
+
+    navigator.serviceWorker.addEventListener("controllerchange", handleControllerChange);
+
+    const handleWaitingServiceWorker = (registration: ServiceWorkerRegistration) => {
+      registrationRef.current = registration;
+      if (!isMounted) {
+        return;
+      }
+
+      setNeedRefresh(true);
+      setOfflineReady(false);
+    };
+
+    const handleInstalledServiceWorker = (registration: ServiceWorkerRegistration) => {
+      registrationRef.current = registration;
+      if (!isMounted) {
+        return;
+      }
+
+      if (navigator.serviceWorker.controller) {
+        setNeedRefresh(true);
+        setOfflineReady(false);
+        return;
+      }
+
+      setOfflineReady(true);
+    };
+
+    const trackRegistration = (registration: ServiceWorkerRegistration) => {
+      registrationRef.current = registration;
+      onRegisteredRef.current?.(registration);
+
+      if (registration.waiting) {
+        handleWaitingServiceWorker(registration);
+      }
+
+      registration.addEventListener("updatefound", () => {
+        const installingWorker = registration.installing;
+        if (!installingWorker) {
+          return;
+        }
+
+        installingWorker.addEventListener("statechange", () => {
+          if (installingWorker.state === "installed") {
+            handleInstalledServiceWorker(registration);
+          }
+        });
+      });
+    };
+
+    void navigator.serviceWorker
+      .register(serviceWorkerPathRef.current)
+      .then((registration) => {
+        if (!isMounted) {
+          return;
+        }
+
+        trackRegistration(registration);
+        return navigator.serviceWorker.ready.then(() => {
+          if (!isMounted || navigator.serviceWorker.controller) {
+            return;
+          }
+
+          setOfflineReady(true);
+        });
+      })
+      .catch((error: Error) => {
+        if (isMounted) {
+          onRegisterErrorRef.current?.(error);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+      navigator.serviceWorker.removeEventListener("controllerchange", handleControllerChange);
+    };
+  }, []);
+
+  return {
+    offlineReady: [offlineReady, setOfflineReady],
+    needRefresh: [needRefresh, setNeedRefresh],
+    updateServiceWorker: (reload = true) => {
+      shouldReloadRef.current = reload;
+      registrationRef.current?.waiting?.postMessage({ type: "SKIP_WAITING" });
+    },
+  };
+}
+
+function subscribeOnline(onStoreChange: () => void) {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+
+  window.addEventListener("online", onStoreChange);
+  window.addEventListener("offline", onStoreChange);
+
+  return () => {
+    window.removeEventListener("online", onStoreChange);
+    window.removeEventListener("offline", onStoreChange);
+  };
+}
+
+function getOnlineSnapshot() {
+  if (typeof navigator === "undefined") {
+    return true;
+  }
+
+  return navigator.onLine;
+}
+
+export interface UpdateGuardCopy {
+  offlineReady?: string;
+  newContentAvailable?: string;
+  refreshButton?: string;
+  closeButton?: string;
+  offlineMessage?: string;
+  offlineStaleMessage?: string;
+}
+
+export interface UpdateGuardProps {
+  children: ReactNode;
+  serviceWorkerPath?: string;
+  hasStaleData?: boolean;
+  hideInDev?: boolean;
+  copy?: UpdateGuardCopy;
+}
+
+function UpdateGuardClient({
+  serviceWorkerPath,
+  hasStaleData = false,
+  hideInDev = true,
+  copy,
+}: Omit<UpdateGuardProps, "children">) {
+  const isDev =
+    typeof import.meta !== "undefined" &&
+    typeof import.meta.env !== "undefined" &&
+    Boolean(import.meta.env.DEV);
+
+  const {
+    offlineReady: [offlineReady, setOfflineReady],
+    needRefresh: [needRefresh, setNeedRefresh],
+    updateServiceWorker,
+  } = useRegisterSW({ serviceWorkerPath });
+
+  const isOnline = useSyncExternalStore(subscribeOnline, getOnlineSnapshot, () => true);
+
+  const closePrompt = () => {
+    setOfflineReady(false);
+    setNeedRefresh(false);
+  };
+
+  const offlineMessage = useMemo(() => {
+    if (isOnline) {
+      return null;
+    }
+
+    return hasStaleData
+      ? (copy?.offlineStaleMessage ?? "Offline - showing cached data where available")
+      : (copy?.offlineMessage ?? "Offline - data may be unavailable");
+  }, [copy?.offlineMessage, copy?.offlineStaleMessage, hasStaleData, isOnline]);
+
+  if (hideInDev && isDev) {
+    return null;
+  }
+
+  return (
+    <>
+      {offlineMessage ? (
+        <div className="fixed inset-x-0 bottom-16 z-50 flex justify-center px-4">
+          <div className="border-border bg-surface flex items-center gap-3 rounded-md border px-4 py-2">
+            <span className="text-text-primary text-sm">{offlineMessage}</span>
+          </div>
+        </div>
+      ) : null}
+
+      {offlineReady || needRefresh ? (
+        <div className="fixed inset-x-0 bottom-4 z-50 flex justify-center px-4">
+          <div className="border-border bg-surface flex items-center gap-3 rounded-md border px-4 py-2">
+            <span className="text-text-primary text-sm">
+              {offlineReady
+                ? (copy?.offlineReady ?? "App ready to work offline")
+                : (copy?.newContentAvailable ?? "New content available")}
+            </span>
+            {needRefresh ? (
+              <button
+                type="button"
+                onClick={() => updateServiceWorker(true)}
+                className="text-accent text-sm font-semibold"
+              >
+                {copy?.refreshButton ?? "Refresh"}
+              </button>
+            ) : null}
+            <button type="button" onClick={closePrompt} className="text-text-secondary text-sm">
+              {copy?.closeButton ?? "Close"}
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * Registers a service worker and surfaces "offline ready" / "update
+ * available" prompts around `children`. No-op (renders only `children`) when
+ * rendered on the server.
+ */
+export function UpdateGuard({
+  children,
+  serviceWorkerPath,
+  hasStaleData = false,
+  hideInDev = true,
+  copy,
+}: UpdateGuardProps) {
+  const isClient = typeof window !== "undefined";
+
+  return (
+    <>
+      {children}
+      {isClient ? (
+        <UpdateGuardClient
+          serviceWorkerPath={serviceWorkerPath}
+          hasStaleData={hasStaleData}
+          hideInDev={hideInDev}
+          copy={copy}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/packages/ui/src/components/forms/date-month-select.stories.tsx
+++ b/packages/ui/src/components/forms/date-month-select.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+import { DateMonthSelect, getCurrentMonthYear } from "./date-month-select";
+
+const meta = {
+  title: "Forms/DateMonthSelect",
+  component: DateMonthSelect,
+  tags: ["autodocs"],
+} satisfies Meta<typeof DateMonthSelect>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function DateMonthSelectPreview() {
+  const [value, setValue] = useState(getCurrentMonthYear());
+  return <DateMonthSelect selectedMonthYear={value} onMonthChange={setValue} />;
+}
+
+export const Default: Story = {
+  args: {
+    selectedMonthYear: getCurrentMonthYear(),
+    onMonthChange: () => {},
+  },
+  render: () => <DateMonthSelectPreview />,
+};

--- a/packages/ui/src/components/forms/date-month-select.tsx
+++ b/packages/ui/src/components/forms/date-month-select.tsx
@@ -1,0 +1,70 @@
+import { Calendar } from "lucide-react";
+import { useMemo } from "react";
+
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./select";
+
+interface MonthOption {
+  value: string;
+  label: string;
+}
+
+export interface DateMonthSelectProps {
+  selectedMonthYear: string;
+  onMonthChange: (value: string) => void;
+  monthsBack?: number;
+  className?: string;
+  placeholder?: string;
+}
+
+/** Select a `YYYY-MM` month from the last `monthsBack` months. */
+export function DateMonthSelect({
+  selectedMonthYear,
+  onMonthChange,
+  monthsBack = 12,
+  className = "w-[200px]",
+  placeholder = "Select month",
+}: DateMonthSelectProps) {
+  const monthOptions = useMemo<MonthOption[]>(() => {
+    const options: MonthOption[] = [];
+    const today = new Date();
+    for (let i = 0; i < monthsBack; i++) {
+      const date = new Date(today.getFullYear(), today.getMonth() - i, 1);
+      const year = date.getFullYear();
+      const month = (date.getMonth() + 1).toString().padStart(2, "0");
+      options.push({
+        value: `${year}-${month}`,
+        label: date.toLocaleString("default", { month: "long", year: "numeric" }),
+      });
+    }
+    return options;
+  }, [monthsBack]);
+
+  return (
+    <div className="flex items-center gap-2">
+      <Calendar className="size-4" />
+      <Select
+        value={selectedMonthYear}
+        onValueChange={(v: string | null) => v != null && onMonthChange(v)}
+      >
+        <SelectTrigger className={className}>
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          {monthOptions.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+/** Current month in `YYYY-MM` format. */
+export const getCurrentMonthYear = () => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = (now.getMonth() + 1).toString().padStart(2, "0");
+  return `${year}-${month}`;
+};

--- a/packages/ui/src/components/forms/drop-zone.stories.tsx
+++ b/packages/ui/src/components/forms/drop-zone.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+import { DropZone } from "./drop-zone";
+
+const meta = {
+  title: "Forms/DropZone",
+  component: DropZone,
+  tags: ["autodocs"],
+} satisfies Meta<typeof DropZone>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function DropZonePreview({ isImporting = false }: { isImporting?: boolean }) {
+  const [dragActive, setDragActive] = useState(false);
+  const [files, setFiles] = useState<File[]>([]);
+
+  return (
+    <div className="w-96 space-y-3">
+      <DropZone
+        isImporting={isImporting}
+        dragActive={dragActive}
+        onDragOver={() => setDragActive(true)}
+        onDragLeave={() => setDragActive(false)}
+        onDrop={setFiles}
+        onChange={setFiles}
+        accept=".csv"
+        helpText="Supported formats: CSV"
+      />
+      {files.length > 0 ? (
+        <p className="text-muted-foreground text-sm">
+          {files.length} file{files.length > 1 ? "s" : ""} selected
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+const baseArgs = {
+  isImporting: false,
+  dragActive: false,
+  onDrop: () => {},
+  onDragOver: () => {},
+  onDragLeave: () => {},
+};
+
+export const Default: Story = {
+  args: baseArgs,
+  render: () => <DropZonePreview />,
+};
+
+export const Importing: Story = {
+  args: { ...baseArgs, isImporting: true },
+  render: () => <DropZonePreview isImporting />,
+};

--- a/packages/ui/src/components/forms/drop-zone.tsx
+++ b/packages/ui/src/components/forms/drop-zone.tsx
@@ -1,0 +1,145 @@
+import type React from "react";
+import { useCallback, useId } from "react";
+
+import { cn } from "../../lib/utils";
+
+export interface DropZoneProps {
+  isImporting: boolean;
+  dragActive: boolean;
+  onDrop: (files: File[]) => void;
+  onDragOver: () => void;
+  onDragLeave: () => void;
+  onChange?: (files: File[]) => void;
+  accept?: string;
+  multiple?: boolean;
+  className?: string;
+  label?: string;
+  helpText?: string;
+}
+
+/** Drag-and-drop file picker with a click-to-browse fallback. */
+export function DropZone({
+  isImporting,
+  dragActive,
+  onDrop,
+  onDragOver,
+  onDragLeave,
+  onChange,
+  accept,
+  multiple = true,
+  className,
+  label = "Drag and drop files here, or",
+  helpText,
+}: DropZoneProps) {
+  const inputId = useId();
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+      onDragLeave();
+
+      if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+        onDrop(Array.from(e.dataTransfer.files));
+      }
+    },
+    [onDrop, onDragLeave],
+  );
+
+  const triggerFileInput = useCallback(() => {
+    if (!isImporting) {
+      document.getElementById(inputId)?.click();
+    }
+  }, [isImporting, inputId]);
+
+  const handleDragOver = useCallback(
+    (e: React.DragEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+      onDragOver();
+    },
+    [onDragOver],
+  );
+
+  const handleDragLeave = useCallback(
+    (e: React.DragEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+      onDragLeave();
+    },
+    [onDragLeave],
+  );
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.stopPropagation();
+      triggerFileInput();
+    },
+    [triggerFileInput],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        e.stopPropagation();
+        triggerFileInput();
+      }
+    },
+    [triggerFileInput],
+  );
+
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      e.stopPropagation();
+      if (onChange) {
+        onChange(e.target.files ? Array.from(e.target.files) : []);
+      }
+    },
+    [onChange],
+  );
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        "relative border-2 border-dashed p-12",
+        {
+          "border-primary bg-primary/5": dragActive,
+          "border-border bg-muted": !dragActive,
+        },
+        "flex flex-col items-center justify-center gap-4",
+        {
+          "pointer-events-none cursor-not-allowed": isImporting,
+        },
+        className,
+      )}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      tabIndex={isImporting ? -1 : 0}
+      aria-disabled={isImporting}
+      aria-label="Upload file area. Press Enter or Space to open file browser"
+    >
+      <input
+        id={inputId}
+        type="file"
+        multiple={multiple}
+        accept={accept}
+        onChange={handleInputChange}
+        className="sr-only"
+        disabled={isImporting}
+        aria-label="File input"
+      />
+
+      <div className="space-y-2 text-center">
+        <p className="text-muted-foreground">
+          {label} <span className="text-primary font-medium">click to browse</span>
+        </p>
+        {helpText ? <p className="text-muted-foreground text-sm">{helpText}</p> : null}
+      </div>
+    </button>
+  );
+}

--- a/packages/ui/src/components/forms/entity-select.stories.tsx
+++ b/packages/ui/src/components/forms/entity-select.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+import { EntitySelect } from "./entity-select";
+
+const meta = {
+  title: "Forms/EntitySelect",
+  component: EntitySelect,
+  tags: ["autodocs"],
+} satisfies Meta<typeof EntitySelect>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const options = [
+  { id: "checking", name: "Checking" },
+  { id: "savings", name: "Savings" },
+  { id: "credit-card", name: "Credit Card" },
+];
+
+function EntitySelectPreview() {
+  const [value, setValue] = useState("all");
+  return (
+    <EntitySelect
+      value={value}
+      onValueChange={setValue}
+      options={options}
+      allOptionLabel="All accounts"
+      placeholder="All accounts"
+      label="Account"
+      showLabel
+    />
+  );
+}
+
+export const Default: Story = {
+  args: {
+    value: "all",
+    onValueChange: () => {},
+    options,
+  },
+  render: () => <EntitySelectPreview />,
+};
+
+export const Loading: Story = {
+  args: {
+    value: "all",
+    onValueChange: () => {},
+    options: [],
+    isLoading: true,
+    label: "Account",
+    showLabel: true,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    value: "all",
+    onValueChange: () => {},
+    options: [],
+    label: "Account",
+    showLabel: true,
+    emptyLabel: "No accounts available",
+  },
+};

--- a/packages/ui/src/components/forms/entity-select.tsx
+++ b/packages/ui/src/components/forms/entity-select.tsx
@@ -1,0 +1,79 @@
+import { useId } from "react";
+
+import { Label } from "../primitives/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./select";
+
+export interface EntitySelectOption {
+  id: string;
+  name: string;
+}
+
+export interface EntitySelectProps {
+  value: string;
+  onValueChange: (value: string) => void;
+  options: EntitySelectOption[];
+  isLoading?: boolean;
+  placeholder?: string;
+  label?: string;
+  showLabel?: boolean;
+  allOptionLabel?: string;
+  emptyLabel?: string;
+  className?: string;
+}
+
+/** Labeled `Select` over an `{ id, name }[]` list, with loading/empty states and an "all" option. */
+export function EntitySelect({
+  value,
+  onValueChange,
+  options,
+  isLoading = false,
+  placeholder = "All",
+  label = "Filter",
+  showLabel = false,
+  allOptionLabel = "All",
+  emptyLabel = "No options available",
+  className,
+}: EntitySelectProps) {
+  const id = useId();
+
+  const selectElement = (
+    <Select
+      name={label}
+      value={value}
+      onValueChange={(v: string | null) => v != null && onValueChange(v)}
+    >
+      <SelectTrigger id={id} className={className}>
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent className="max-h-[250px] overflow-y-auto">
+        <SelectItem value="all">{allOptionLabel}</SelectItem>
+        {isLoading ? (
+          <SelectItem value="loading" disabled>
+            Loading...
+          </SelectItem>
+        ) : options.length === 0 ? (
+          <SelectItem value="empty" disabled>
+            {emptyLabel}
+          </SelectItem>
+        ) : (
+          options.map((option) => (
+            <SelectItem key={option.id} value={option.id}>
+              {option.name}
+            </SelectItem>
+          ))
+        )}
+      </SelectContent>
+    </Select>
+  );
+
+  if (showLabel) {
+    return (
+      <div className="space-y-2">
+        <Label htmlFor={id}>{label}</Label>
+        {selectElement}
+      </div>
+    );
+  }
+
+  return selectElement;
+}

--- a/packages/ui/src/components/forms/group-by-select.stories.tsx
+++ b/packages/ui/src/components/forms/group-by-select.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+import { GroupBySelect } from "./group-by-select";
+
+const meta = {
+  title: "Forms/GroupBySelect",
+  component: GroupBySelect,
+  tags: ["autodocs"],
+} satisfies Meta<typeof GroupBySelect>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function GroupBySelectPreview() {
+  const [groupBy, setGroupBy] = useState<"month" | "week" | "day">("month");
+  return <GroupBySelect groupBy={groupBy} onGroupByChange={setGroupBy} />;
+}
+
+export const Default: Story = {
+  args: {
+    groupBy: "month",
+    onGroupByChange: () => {},
+  },
+  render: () => <GroupBySelectPreview />,
+};

--- a/packages/ui/src/components/forms/group-by-select.tsx
+++ b/packages/ui/src/components/forms/group-by-select.tsx
@@ -1,0 +1,47 @@
+import { useId } from "react";
+
+import { Label } from "../primitives/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./select";
+
+type GroupByOption = "month" | "week" | "day";
+
+export interface GroupBySelectProps {
+  groupBy: GroupByOption;
+  onGroupByChange: (value: GroupByOption) => void;
+  label?: string;
+  className?: string;
+}
+
+/** Month/week/day grouping select. */
+export function GroupBySelect({
+  groupBy,
+  onGroupByChange,
+  label = "Group By",
+  className,
+}: GroupBySelectProps) {
+  const id = useId();
+
+  return (
+    <div className={`space-y-2 ${className || ""}`}>
+      <Label htmlFor={id}>{label}</Label>
+      <Select
+        name="groupBy"
+        value={groupBy}
+        onValueChange={(value) => {
+          if (value === "month" || value === "week" || value === "day") {
+            onGroupByChange(value);
+          }
+        }}
+      >
+        <SelectTrigger id={id}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="month">Month</SelectItem>
+          <SelectItem value="week">Week</SelectItem>
+          <SelectItem value="day">Day</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/packages/ui/src/components/forms/index.ts
+++ b/packages/ui/src/components/forms/index.ts
@@ -2,9 +2,19 @@ export { Calendar } from "./calendar";
 export type { CalendarProps } from "./calendar";
 export { DatePicker } from "./date-picker";
 export type { DatePickerProps } from "./date-picker";
+export { DateMonthSelect, getCurrentMonthYear } from "./date-month-select";
+export type { DateMonthSelectProps } from "./date-month-select";
+export { DropZone } from "./drop-zone";
+export type { DropZoneProps } from "./drop-zone";
+export { EntitySelect } from "./entity-select";
+export type { EntitySelectOption, EntitySelectProps } from "./entity-select";
 export { Field } from "./field";
 export type { FieldProps } from "./field";
+export { GroupBySelect } from "./group-by-select";
+export type { GroupBySelectProps } from "./group-by-select";
 export { Input } from "./input";
+export { PasskeyManagement } from "./passkey-management";
+export type { PasskeyManagementProps, PasskeyRecord } from "./passkey-management";
 export { RadioGroup, RadioGroupItem } from "./radio-group";
 export {
   Select,

--- a/packages/ui/src/components/forms/passkey-management.stories.tsx
+++ b/packages/ui/src/components/forms/passkey-management.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+import { PasskeyManagement, type PasskeyRecord } from "./passkey-management";
+
+const meta = {
+  title: "Forms/PasskeyManagement",
+  component: PasskeyManagement,
+  tags: ["autodocs"],
+} satisfies Meta<typeof PasskeyManagement>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const initialPasskeys: PasskeyRecord[] = [
+  { id: "1", name: "MacBook Pro", createdAt: "2025-01-15T00:00:00.000Z" },
+  { id: "2", name: "iPhone", createdAt: "2025-03-02T00:00:00.000Z" },
+];
+
+function PasskeyManagementPreview({ withError = false }: { withError?: boolean }) {
+  const [passkeys, setPasskeys] = useState(initialPasskeys);
+
+  return (
+    <div className="w-96">
+      <PasskeyManagement
+        passkeys={passkeys}
+        error={withError ? "Could not delete passkey. Please try again." : null}
+        onAdd={async () => {
+          setPasskeys((prev) => [
+            ...prev,
+            {
+              id: String(prev.length + 1),
+              name: "New device",
+              createdAt: new Date().toISOString(),
+            },
+          ]);
+          return true;
+        }}
+        onDelete={async (id) => {
+          setPasskeys((prev) => prev.filter((pk) => pk.id !== id));
+          return true;
+        }}
+      />
+    </div>
+  );
+}
+
+export const Default: Story = {
+  args: {
+    passkeys: initialPasskeys,
+    onAdd: async () => true,
+    onDelete: async () => true,
+  },
+  render: () => <PasskeyManagementPreview />,
+};
+
+export const Empty: Story = {
+  args: {
+    passkeys: [],
+    onAdd: async () => true,
+    onDelete: async () => true,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    isLoading: true,
+    onAdd: async () => true,
+    onDelete: async () => true,
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    passkeys: initialPasskeys,
+    error: "Could not delete passkey. Please try again.",
+    onAdd: async () => true,
+    onDelete: async () => true,
+  },
+  render: () => <PasskeyManagementPreview withError />,
+};

--- a/packages/ui/src/components/forms/passkey-management.tsx
+++ b/packages/ui/src/components/forms/passkey-management.tsx
@@ -1,0 +1,138 @@
+import { KeyRound, Plus, Trash2 } from "lucide-react";
+import { useCallback, useState } from "react";
+
+import { Button } from "../primitives/button";
+
+export interface PasskeyRecord {
+  id: string;
+  name?: string;
+  createdAt?: string;
+}
+
+export interface PasskeyManagementProps {
+  passkeys?: PasskeyRecord[];
+  isLoading?: boolean;
+  error?: string | null;
+  onAdd: () => Promise<boolean>;
+  onDelete: (id: string) => Promise<boolean>;
+}
+
+/** List, add, and remove passkeys. The host app owns the WebAuthn ceremony via `onAdd`/`onDelete`. */
+export function PasskeyManagement({
+  passkeys: passkeysProp,
+  isLoading = false,
+  error: externalError,
+  onAdd,
+  onDelete,
+}: PasskeyManagementProps) {
+  const [adding, setAdding] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const passkeys = passkeysProp ?? [];
+  const error = externalError ?? actionError;
+
+  const handleAdd = useCallback(async () => {
+    setAdding(true);
+    setActionError(null);
+    try {
+      const success = await onAdd();
+      if (!success) {
+        setActionError("Passkey registration was cancelled or failed.");
+      }
+    } catch {
+      setActionError("An error occurred during passkey registration.");
+    } finally {
+      setAdding(false);
+    }
+  }, [onAdd]);
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      setDeletingId(id);
+      setActionError(null);
+      try {
+        const success = await onDelete(id);
+        if (!success) {
+          throw new Error("Failed to delete passkey");
+        }
+      } catch {
+        setActionError("Could not delete passkey. Please try again.");
+      } finally {
+        setDeletingId(null);
+      }
+    },
+    [onDelete],
+  );
+
+  return (
+    <section aria-labelledby="passkey-heading" className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 id="passkey-heading" className="subheading-4 text-text-primary">
+            Passkeys
+          </h2>
+          <p className="body-3 text-text-secondary">
+            Sign in without a password using biometrics or a security key.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => void handleAdd()}
+          disabled={adding}
+          aria-label="Add a passkey"
+        >
+          <Plus className="size-4" aria-hidden />
+          {adding ? "Adding..." : "Add passkey"}
+        </Button>
+      </div>
+
+      {error ? (
+        <p role="alert" className="text-destructive text-sm">
+          {error}
+        </p>
+      ) : null}
+
+      {isLoading ? (
+        <p className="text-muted-foreground text-sm">Loading passkeys...</p>
+      ) : passkeys.length === 0 ? (
+        <div className="border-border text-text-secondary flex items-center gap-3 border border-dashed p-4 text-sm">
+          <KeyRound className="size-4 shrink-0" aria-hidden />
+          <span>No passkeys registered. Add one to sign in faster.</span>
+        </div>
+      ) : (
+        <ul className="space-y-2" aria-label="Registered passkeys">
+          {passkeys.map((pk) => (
+            <li
+              key={pk.id}
+              className="border-border flex items-center justify-between border px-4 py-3 text-sm"
+            >
+              <div className="flex items-center gap-3">
+                <KeyRound className="text-text-secondary size-4 shrink-0" aria-hidden />
+                <div>
+                  <span className="font-medium">{pk.name ?? "Passkey"}</span>
+                  {pk.createdAt ? (
+                    <span className="text-text-tertiary ml-2 text-xs">
+                      Added {new Date(pk.createdAt).toLocaleDateString()}
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => void handleDelete(pk.id)}
+                disabled={deletingId === pk.id}
+                aria-label={`Remove passkey ${pk.name ?? pk.id}`}
+                className="hover:text-destructive text-muted-foreground focus-visible:ring-ring rounded-sm focus-visible:ring-2 focus-visible:outline-none disabled:opacity-50"
+              >
+                <Trash2 className="size-4" aria-hidden />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/packages/ui/src/components/layout/index.ts
+++ b/packages/ui/src/components/layout/index.ts
@@ -1,2 +1,5 @@
 export { ScrollArea } from "./scroll-area";
 export type { ScrollAreaProps } from "./scroll-area";
+export { SectionIntro } from "./section-intro";
+export type { SectionIntroProps } from "./section-intro";
+export { SurfacePanel } from "./surface-panel";

--- a/packages/ui/src/components/layout/section-intro.stories.tsx
+++ b/packages/ui/src/components/layout/section-intro.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Button } from "../primitives/button";
+import { SectionIntro } from "./section-intro";
+
+const meta = {
+  title: "Layout/SectionIntro",
+  component: SectionIntro,
+  tags: ["autodocs"],
+} satisfies Meta<typeof SectionIntro>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: "Accounts",
+    description: "Connect and manage the accounts you track.",
+  },
+};
+
+export const WithEyebrowAndActions: Story = {
+  args: {
+    eyebrow: "Settings",
+    title: "Security",
+    description: "Manage how you sign in and keep your account secure.",
+    actions: <Button variant="outline">Add passkey</Button>,
+  },
+};

--- a/packages/ui/src/components/layout/section-intro.tsx
+++ b/packages/ui/src/components/layout/section-intro.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+
+export interface SectionIntroProps {
+  eyebrow?: ReactNode;
+  title: ReactNode;
+  description?: ReactNode;
+  actions?: ReactNode;
+}
+
+/**
+ * Page-level heading composition: eyebrow label, title, description, and an
+ * optional trailing actions slot.
+ */
+export function SectionIntro({ eyebrow, title, description, actions }: SectionIntroProps) {
+  return (
+    <div className="flex items-start justify-between gap-6">
+      <div className="min-w-0 flex-1">
+        {eyebrow ? (
+          <div className="text-text-tertiary mb-3 text-[11px] font-medium tracking-[0.18em] uppercase">
+            {eyebrow}
+          </div>
+        ) : null}
+        <div className="space-y-3">
+          <h1 className="text-title-2 text-foreground font-semibold tracking-tight">{title}</h1>
+          {description ? <p className="text-body-3 text-text-secondary">{description}</p> : null}
+        </div>
+      </div>
+      {actions ? <div className="shrink-0">{actions}</div> : null}
+    </div>
+  );
+}

--- a/packages/ui/src/components/layout/surface-panel.stories.tsx
+++ b/packages/ui/src/components/layout/surface-panel.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { SurfacePanel } from "./surface-panel";
+
+const meta = {
+  title: "Layout/SurfacePanel",
+  component: SurfacePanel,
+  tags: ["autodocs"],
+} satisfies Meta<typeof SurfacePanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="w-80">
+      <SurfacePanel>
+        <p className="text-muted-foreground text-sm">Panel content goes here.</p>
+      </SurfacePanel>
+    </div>
+  ),
+};
+
+export const AsSection: Story = {
+  render: () => (
+    <div className="w-80">
+      <SurfacePanel as="section" aria-label="Example panel">
+        <p className="text-muted-foreground text-sm">Rendered as a semantic &lt;section&gt;.</p>
+      </SurfacePanel>
+    </div>
+  ),
+};

--- a/packages/ui/src/components/layout/surface-panel.tsx
+++ b/packages/ui/src/components/layout/surface-panel.tsx
@@ -1,0 +1,15 @@
+import type { ComponentPropsWithoutRef, ElementType } from "react";
+
+type SurfacePanelProps<T extends ElementType = "div"> = { as?: T } & Omit<
+  ComponentPropsWithoutRef<T>,
+  "as" | "className"
+>;
+
+/** Rounded, bordered surface panel — a generic content container. */
+export function SurfacePanel<T extends ElementType = "div">({
+  as,
+  ...props
+}: SurfacePanelProps<T>) {
+  const Component = as ?? "div";
+  return <Component className="border-border bg-surface rounded-3xl border p-5" {...props} />;
+}

--- a/packages/ui/src/components/navigation/index.ts
+++ b/packages/ui/src/components/navigation/index.ts
@@ -1,3 +1,7 @@
 export { AppNavigation } from "./app-navigation";
 export type { AppNavigationCta, AppNavigationLink, AppNavigationProps } from "./app-navigation";
+export { PaginationControls } from "./pagination-controls";
+export type { PaginationControlsProps } from "./pagination-controls";
+export { RouteLink } from "./route-link";
+export type { RouteLinkProps } from "./route-link";
 export { Tabs, TabsContent, TabsList, TabsTrigger } from "./tabs";

--- a/packages/ui/src/components/navigation/pagination-controls.stories.tsx
+++ b/packages/ui/src/components/navigation/pagination-controls.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+import { PaginationControls } from "./pagination-controls";
+
+const meta = {
+  title: "Navigation/PaginationControls",
+  component: PaginationControls,
+  tags: ["autodocs"],
+} satisfies Meta<typeof PaginationControls>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function PaginationPreview({ totalPages }: { totalPages: number }) {
+  const [currentPage, setCurrentPage] = useState(0);
+  return (
+    <PaginationControls
+      currentPage={currentPage}
+      totalPages={totalPages}
+      onPageChange={setCurrentPage}
+    />
+  );
+}
+
+const baseArgs = {
+  currentPage: 0,
+  totalPages: 5,
+  onPageChange: () => {},
+};
+
+export const Default: Story = {
+  args: baseArgs,
+  render: () => <PaginationPreview totalPages={5} />,
+};
+
+export const SinglePage: Story = {
+  name: "Single page (renders nothing)",
+  args: { ...baseArgs, totalPages: 1 },
+  render: () => <PaginationPreview totalPages={1} />,
+};

--- a/packages/ui/src/components/navigation/pagination-controls.tsx
+++ b/packages/ui/src/components/navigation/pagination-controls.tsx
@@ -1,0 +1,50 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+import { Button } from "../primitives/button";
+
+export interface PaginationControlsProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+/** Zero-indexed prev/next pagination control. Renders nothing for a single page. */
+export function PaginationControls({
+  currentPage,
+  totalPages,
+  onPageChange,
+}: PaginationControlsProps) {
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  return (
+    <div className="body-3 text-muted-foreground flex items-center justify-end gap-2">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="border-dashed"
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={currentPage === 0}
+      >
+        <ChevronLeft className="size-4" aria-hidden />
+        Previous
+      </Button>
+      <span className="body-4 text-foreground">
+        Page {currentPage + 1} of {totalPages}
+      </span>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="border-dashed"
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage >= totalPages - 1}
+      >
+        Next
+        <ChevronRight className="size-4" aria-hidden />
+      </Button>
+    </div>
+  );
+}

--- a/packages/ui/src/components/navigation/route-link.stories.tsx
+++ b/packages/ui/src/components/navigation/route-link.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { RouteLink } from "./route-link";
+
+const meta = {
+  title: "Navigation/RouteLink",
+  component: RouteLink,
+  tags: ["autodocs"],
+} satisfies Meta<typeof RouteLink>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: "View accounts",
+    href: "#",
+    className: "text-accent underline",
+  },
+};
+
+export const WithOnNavigate: Story = {
+  name: "With onNavigate callback",
+  args: {
+    children: "Go to analytics",
+    href: "#",
+    className: "text-accent underline",
+    onNavigate: () => console.log("route loading started"),
+  },
+};

--- a/packages/ui/src/components/navigation/route-link.tsx
+++ b/packages/ui/src/components/navigation/route-link.tsx
@@ -1,0 +1,42 @@
+import type { ComponentPropsWithoutRef, ElementType, MouseEvent, ReactNode } from "react";
+import { useCallback } from "react";
+
+type RouteLinkOwnProps<T extends ElementType> = {
+  as?: T;
+  children: ReactNode;
+  /** Called before the click is forwarded — e.g. to flip a route-loading store. */
+  onNavigate?: () => void;
+};
+
+export type RouteLinkProps<T extends ElementType = "a"> = RouteLinkOwnProps<T> &
+  Omit<ComponentPropsWithoutRef<T>, keyof RouteLinkOwnProps<T>>;
+
+/**
+ * Polymorphic link that fires `onNavigate` before `onClick`. Pass your
+ * router's `Link` component as `as` for client-side navigation (e.g.
+ * `as={Link} to="/accounts"`); the host app owns any route-loading state via
+ * `onNavigate` instead of a hardcoded store.
+ */
+export function RouteLink<T extends ElementType = "a">({
+  as,
+  children,
+  onNavigate,
+  onClick,
+  ...props
+}: RouteLinkProps<T>) {
+  const Component = (as ?? "a") as ElementType;
+
+  const handleClick = useCallback(
+    (e: MouseEvent) => {
+      onNavigate?.();
+      (onClick as ((e: MouseEvent) => void) | undefined)?.(e);
+    },
+    [onNavigate, onClick],
+  );
+
+  return (
+    <Component onClick={handleClick} {...props}>
+      {children}
+    </Component>
+  );
+}

--- a/packages/ui/src/components/primitives/index.ts
+++ b/packages/ui/src/components/primitives/index.ts
@@ -11,3 +11,5 @@ export {
   CardTitle,
 } from "./card";
 export { Label } from "./label";
+export { StatusBadge } from "./status-badge";
+export type { StatusBadgeConfig, StatusBadgeProps } from "./status-badge";

--- a/packages/ui/src/components/primitives/status-badge.stories.tsx
+++ b/packages/ui/src/components/primitives/status-badge.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CheckCircle, Clock, XCircle } from "lucide-react";
+
+import { StatusBadge, type StatusBadgeConfig } from "./status-badge";
+
+type ConnectionStatus = "active" | "error" | "pending" | "revoked";
+
+const connectionStatusConfig: Record<ConnectionStatus, StatusBadgeConfig> = {
+  active: { label: "Active", variant: "default", icon: <CheckCircle className="mr-1 size-3" /> },
+  error: { label: "Error", variant: "destructive", icon: <XCircle className="mr-1 size-3" /> },
+  pending: { label: "Pending", variant: "secondary", icon: <Clock className="mr-1 size-3" /> },
+  revoked: { label: "Revoked", variant: "outline" },
+};
+
+const meta = {
+  title: "Primitives/StatusBadge",
+  component: StatusBadge<ConnectionStatus>,
+  tags: ["autodocs"],
+} satisfies Meta<typeof StatusBadge<ConnectionStatus>>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    status: "active",
+    config: connectionStatusConfig,
+  },
+};
+
+export const AllStatuses: Story = {
+  args: {
+    status: "active",
+    config: connectionStatusConfig,
+  },
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <StatusBadge status="active" config={connectionStatusConfig} />
+      <StatusBadge status="error" config={connectionStatusConfig} />
+      <StatusBadge status="pending" config={connectionStatusConfig} />
+      <StatusBadge status="revoked" config={connectionStatusConfig} />
+    </div>
+  ),
+};
+
+export const WithFallback: Story = {
+  args: {
+    status: null,
+    config: connectionStatusConfig,
+    fallback: { label: "Unknown", variant: "outline" },
+  },
+};

--- a/packages/ui/src/components/primitives/status-badge.tsx
+++ b/packages/ui/src/components/primitives/status-badge.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+
+import { Badge, type badgeVariants } from "./badge";
+import type { VariantProps } from "class-variance-authority";
+
+export interface StatusBadgeConfig {
+  label: string;
+  variant?: VariantProps<typeof badgeVariants>["variant"];
+  className?: string;
+  icon?: ReactNode;
+}
+
+export interface StatusBadgeProps<T extends string> {
+  status: T | null | undefined;
+  config: Record<T, StatusBadgeConfig>;
+  fallback?: StatusBadgeConfig;
+}
+
+/** Renders a `Badge` from a status → { label, variant, icon } config map. */
+export function StatusBadge<T extends string>({ status, config, fallback }: StatusBadgeProps<T>) {
+  const entry = (status != null ? config[status] : undefined) ?? fallback;
+
+  if (!entry) {
+    return null;
+  }
+
+  return (
+    <Badge variant={entry.variant ?? "outline"} className={entry.className}>
+      {entry.icon}
+      {entry.label}
+    </Badge>
+  );
+}

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -3,4 +3,5 @@ export { useDebouncedValue } from "./use-debounced-value";
 export { useFilterState } from "./use-filter-state";
 export { useMediaQuery } from "./use-media-query";
 export { useIsMobile } from "./use-mobile";
+export { useSort } from "./use-sort";
 export type { SortField, SortDirection, SortOption } from "./sort.types";

--- a/packages/ui/src/hooks/use-sort.ts
+++ b/packages/ui/src/hooks/use-sort.ts
@@ -1,0 +1,20 @@
+import { useState } from "react";
+
+import type { SortOption } from "./sort.types";
+
+interface UseSortOptions {
+  initialSortOptions?: SortOption[];
+}
+
+export function useSort(options: UseSortOptions = {}) {
+  const [sortOptions, setSortOptions] = useState<SortOption[]>(options.initialSortOptions ?? []);
+
+  return {
+    sortOptions,
+    addSortOption: (opt: SortOption) => setSortOptions((prev) => [...prev, opt]),
+    updateSortOption: (index: number, opt: SortOption) =>
+      setSortOptions((prev) => prev.map((o, i) => (i === index ? opt : o))),
+    removeSortOption: (index: number) =>
+      setSortOptions((prev) => prev.filter((_, i) => i !== index)),
+  };
+}


### PR DESCRIPTION
Ports the generic components/hooks inventoried out of hominem's finance app into the shared component library, each with Storybook stories:

- Layout: SectionIntro, SurfacePanel
- Data display: MetricCard, SortControls/SortRow
- Feedback: Skeleton, ProgressBar, UpdateGuard, FileUploadStatus(Badge)
- Forms: DateMonthSelect, GroupBySelect, DropZone, PasskeyManagement, EntitySelect (generalizes finance's AccountSelect/TagSelect)
- Navigation: PaginationControls, RouteLink (polymorphic, decoupled from any specific router or loading store)
- Primitives: StatusBadge (generalizes finance's PlaidStatusBadge)
- Hooks: useSort

Bumps the package to 0.2.0 for the new public API surface.