### PR TITLE
Agent/consolidate package updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,11 @@ jobs:
       - name: Wait for postgres
         run: |
           for i in {1..30}; do
-            docker exec postgres-test pg_isready -U postgres && break
+            docker exec postgres-test psql -U postgres -d hominem -c 'SELECT 1' && exit 0
             sleep 1
           done
-      - name: Verify postgres connection
-        run: docker exec postgres-test psql -U postgres -d hominem -c 'SELECT 1'
+          echo "postgres did not become ready with database 'hominem' in time" >&2
+          exit 1
       - name: Run migrations
         run: pnpm --filter @pontistudios/db db:migrate
         env:

--- a/apps/commune/app/routes/case/create.tsx
+++ b/apps/commune/app/routes/case/create.tsx
@@ -131,7 +131,9 @@ export default function CreatePage() {
               rows={2}
               className="border-input bg-background focus:ring-ring w-full resize-none rounded-xl border px-4 py-3 text-sm focus:ring-1 focus:outline-none"
             />
-            <p className="text-muted-foreground text-[10px]">You can edit this if it's not quite right.</p>
+            <p className="text-muted-foreground text-[10px]">
+              You can edit this if it's not quite right.
+            </p>
           </div>
 
           {error && (

--- a/apps/earth/app/routes/tfl.$cameraId.tsx
+++ b/apps/earth/app/routes/tfl.$cameraId.tsx
@@ -66,7 +66,10 @@ export default function TflCamera({ loaderData }: Route.ComponentProps) {
     <div className="space-y-3">
       {/* Header row */}
       <div className="flex items-center justify-between gap-3">
-        <Link to="/tfl" className="text-muted-foreground hover:text-foreground text-xs transition-colors">
+        <Link
+          to="/tfl"
+          className="text-muted-foreground hover:text-foreground text-xs transition-colors"
+        >
           ← Cameras
         </Link>
         <div className="flex items-center gap-1.5">

--- a/apps/health/app/routes/appointments.new.tsx
+++ b/apps/health/app/routes/appointments.new.tsx
@@ -53,7 +53,10 @@ export default function NewAppointment() {
 
   return (
     <div className="container mx-auto flex max-w-md flex-col gap-6 px-4 py-8">
-      <Link to="/appointments" className="text-muted-foreground hover:text-foreground inline-flex text-sm">
+      <Link
+        to="/appointments"
+        className="text-muted-foreground hover:text-foreground inline-flex text-sm"
+      >
         ← Appointments
       </Link>
 
@@ -76,7 +79,9 @@ export default function NewAppointment() {
                 type="button"
                 onClick={() => setSelectedSlot(slot)}
                 className={`flex w-full items-center justify-between rounded-md border p-3 text-left transition-colors ${
-                  isSelected ? "border-foreground bg-primary text-primary-foreground" : "hover:bg-muted/50"
+                  isSelected
+                    ? "border-foreground bg-primary text-primary-foreground"
+                    : "hover:bg-muted/50"
                 }`}
               >
                 <div>

--- a/apps/health/app/routes/home.tsx
+++ b/apps/health/app/routes/home.tsx
@@ -129,7 +129,9 @@ function Section({
         </Link>
       </div>
       {empty ? (
-        <p className="text-muted-foreground rounded-md border py-4 text-center text-sm">{emptyText}</p>
+        <p className="text-muted-foreground rounded-md border py-4 text-center text-sm">
+          {emptyText}
+        </p>
       ) : (
         <div className="flex flex-col gap-2">{children}</div>
       )}

--- a/apps/health/app/routes/medication.tsx
+++ b/apps/health/app/routes/medication.tsx
@@ -106,7 +106,9 @@ export default function MedicationRoute(): JSX.Element {
             {partialDose !== null && (
               <li className="bg-muted/50 border-muted-foreground/20 flex items-center justify-between rounded-md border border-dashed px-4 py-2">
                 <span className="font-medium">Week {Math.floor(totalWeeks) + 1} (partial)</span>
-                <span className="text-muted-foreground tabular-nums">{partialDose.toFixed(1)} mg</span>
+                <span className="text-muted-foreground tabular-nums">
+                  {partialDose.toFixed(1)} mg
+                </span>
               </li>
             )}
           </ul>

--- a/apps/labyrinth/app/components/DetailPage.tsx
+++ b/apps/labyrinth/app/components/DetailPage.tsx
@@ -18,8 +18,10 @@ export function DetailHeader({ back, media, metadata, summary, title }: DetailHe
       </div>
       <div className="flex min-w-0 flex-col gap-4">
         <h1 className="display-1 text-foreground max-w-4xl">{title}</h1>
-        {metadata ? <div className="text-sm text-muted-foreground max-w-2xl">{metadata}</div> : null}
-        <p className="text-base text-foreground max-w-2xl">{summary}</p>
+        {metadata ? (
+          <div className="text-muted-foreground max-w-2xl text-sm">{metadata}</div>
+        ) : null}
+        <p className="text-foreground max-w-2xl text-base">{summary}</p>
       </div>
     </section>
   );
@@ -50,10 +52,10 @@ export function DetailNavigation({ ariaLabel, next, previous }: DetailNavigation
             aria-label={`${previous.label}: ${previous.title}`}
             className="detail-navigation-link group"
           >
-            <span className="text-xs text-muted-foreground group-hover:text-accent transition-colors motion-reduce:transition-none">
+            <span className="text-muted-foreground group-hover:text-accent text-xs transition-colors motion-reduce:transition-none">
               ← {previous.label}
             </span>
-            <span className="text-lg font-semibold tracking-tight text-foreground group-hover:text-accent transition-colors motion-reduce:transition-none">
+            <span className="text-foreground group-hover:text-accent text-lg font-semibold tracking-tight transition-colors motion-reduce:transition-none">
               {previous.title}
             </span>
           </Link>
@@ -65,10 +67,10 @@ export function DetailNavigation({ ariaLabel, next, previous }: DetailNavigation
             aria-label={`${next.label}: ${next.title}`}
             className="detail-navigation-link group sm:ml-auto sm:text-right"
           >
-            <span className="text-xs text-muted-foreground group-hover:text-accent transition-colors motion-reduce:transition-none">
+            <span className="text-muted-foreground group-hover:text-accent text-xs transition-colors motion-reduce:transition-none">
               {next.label} →
             </span>
-            <span className="text-lg font-semibold tracking-tight text-foreground group-hover:text-accent transition-colors motion-reduce:transition-none">
+            <span className="text-foreground group-hover:text-accent text-lg font-semibold tracking-tight transition-colors motion-reduce:transition-none">
               {next.title}
             </span>
           </Link>

--- a/apps/labyrinth/app/components/ListRowMedia.tsx
+++ b/apps/labyrinth/app/components/ListRowMedia.tsx
@@ -39,7 +39,9 @@ export function ListRowMedia({
       </span>
 
       {status === "error" ? (
-        <span className="text-muted-foreground subtext-lg font-semibold tracking-tight relative tracking-wide">{fallback}</span>
+        <span className="text-muted-foreground subtext-lg relative font-semibold tracking-tight tracking-wide">
+          {fallback}
+        </span>
       ) : (
         <img
           ref={imageRef}

--- a/apps/labyrinth/app/components/calendar/Calendar.tsx
+++ b/apps/labyrinth/app/components/calendar/Calendar.tsx
@@ -98,11 +98,11 @@ function TemporalContext({ context }: { context: CalendarEventContext }) {
 
   return (
     <div className="border-border min-w-0 border-t pt-2">
-      <div className="subtext-lg font-semibold tracking-tight text-muted-foreground flex items-center gap-1.5 uppercase">
+      <div className="subtext-lg text-muted-foreground flex items-center gap-1.5 font-semibold tracking-tight uppercase">
         <Icon aria-hidden="true" className="size-3.5 shrink-0" />
         <span>{context.label}</span>
       </div>
-      <p className="text-sm text-foreground mt-1">{context.detail}</p>
+      <p className="text-foreground mt-1 text-sm">{context.detail}</p>
     </div>
   );
 }
@@ -128,7 +128,7 @@ function TemporalMoment({ event, nowMinute }: { event: CalendarEvent; nowMinute:
     >
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
-          <div className="text-xs text-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-1 tabular-nums">
+          <div className="text-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-1 text-xs tabular-nums">
             {Icon && <Icon aria-hidden="true" className="text-accent size-4 shrink-0" />}
             <span>{formatTime(event.startMinute)}</span>
             <span aria-hidden="true">·</span>
@@ -136,13 +136,19 @@ function TemporalMoment({ event, nowMinute }: { event: CalendarEvent; nowMinute:
             {isPresent && <span className="text-accent font-semibold uppercase">Here</span>}
           </div>
 
-          <h3 className={`${isPresent ? "text-xl font-semibold tracking-tight" : "text-base font-semibold"} mt-2`}>{event.title}</h3>
-          <p className={`${isPresent ? "text-sm" : "text-sm"} text-muted-foreground mt-1 max-w-2xl`}>
+          <h3
+            className={`${isPresent ? "text-xl font-semibold tracking-tight" : "text-base font-semibold"} mt-2`}
+          >
+            {event.title}
+          </h3>
+          <p
+            className={`${isPresent ? "text-sm" : "text-sm"} text-muted-foreground mt-1 max-w-2xl`}
+          >
             {event.detail}
           </p>
 
           {event.location && (
-            <p className="text-xs text-muted-foreground mt-2 flex items-center gap-1.5">
+            <p className="text-muted-foreground mt-2 flex items-center gap-1.5 text-xs">
               <MapPin aria-hidden="true" className="size-3.5 shrink-0" />
               {event.location}
             </p>
@@ -150,7 +156,7 @@ function TemporalMoment({ event, nowMinute }: { event: CalendarEvent; nowMinute:
         </div>
 
         {isPresent && (
-          <span className="text-xs text-accent hidden shrink-0 pt-1 uppercase sm:inline">
+          <span className="text-accent hidden shrink-0 pt-1 text-xs uppercase sm:inline">
             Happening now
           </span>
         )}
@@ -189,7 +195,7 @@ function DayLandmark({
     <section data-stream-day={offset}>
       <header className="flex items-center gap-3 py-8">
         <h2 className="ui-data-label text-foreground">{formatDay(date, offset)}</h2>
-        <p className="text-sm text-muted-foreground">{formatDate(date)}</p>
+        <p className="text-muted-foreground text-sm">{formatDate(date)}</p>
         <div className="border-border ml-1 h-px flex-1 border-t" />
       </header>
 
@@ -236,7 +242,7 @@ export function Calendar({ getEvents }: CalendarProps) {
   return (
     <section aria-label="A continuous stream of lived time">
       <div className="mb-2 flex items-center justify-between gap-4">
-        <p className="text-xs text-muted-foreground">A day in motion</p>
+        <p className="text-muted-foreground text-xs">A day in motion</p>
         <button
           type="button"
           onClick={() => scrollToNow()}
@@ -260,7 +266,7 @@ export function Calendar({ getEvents }: CalendarProps) {
             />
           ))
         ) : (
-          <div className="text-sm text-muted-foreground flex min-h-96 items-center justify-center p-6">
+          <div className="text-muted-foreground flex min-h-96 items-center justify-center p-6 text-sm">
             Finding your place in time…
           </div>
         )}

--- a/apps/labyrinth/app/components/games/tetris-game.tsx
+++ b/apps/labyrinth/app/components/games/tetris-game.tsx
@@ -475,7 +475,9 @@ const TetrisGame: FC = () => {
 
         {/* Board column */}
         <div className="flex flex-col items-center gap-3">
-          <h3 className="text-foreground text-sm font-semibold tracking-widest uppercase">Tetris</h3>
+          <h3 className="text-foreground text-sm font-semibold tracking-widest uppercase">
+            Tetris
+          </h3>
 
           <div className="border-border relative overflow-hidden rounded-xl border bg-zinc-950 p-1">
             <div className="grid" style={{ gridTemplateColumns: `repeat(${COLS}, 1.5rem)` }}>

--- a/apps/labyrinth/app/routes/challenges.anagrams.tsx
+++ b/apps/labyrinth/app/routes/challenges.anagrams.tsx
@@ -199,7 +199,9 @@ export default function Anagrams(): JSX.Element {
                         <TableCell className={`font-mono font-medium ${color.row}`}>
                           {step.word}
                         </TableCell>
-                        <TableCell className="text-muted-foreground font-mono">{step.sortedKey}</TableCell>
+                        <TableCell className="text-muted-foreground font-mono">
+                          {step.sortedKey}
+                        </TableCell>
                         <TableCell>
                           <span
                             className={`rounded border px-2 py-0.5 text-xs font-medium ${color.badge}`}

--- a/apps/labyrinth/app/routes/challenges.fee-or-upfront.tsx
+++ b/apps/labyrinth/app/routes/challenges.fee-or-upfront.tsx
@@ -104,7 +104,9 @@ export default function FeeOrUpfront(): JSX.Element {
           </div>
 
           <div className="border-border border-t pt-3">
-            <p className="text-muted-foreground mb-0.5 text-[10px] tracking-wide uppercase">Total</p>
+            <p className="text-muted-foreground mb-0.5 text-[10px] tracking-wide uppercase">
+              Total
+            </p>
             <p
               className={`font-mono text-2xl font-bold tabular-nums ${winnerIsUpfront ? "text-green-700" : ""}`}
             >
@@ -177,7 +179,9 @@ export default function FeeOrUpfront(): JSX.Element {
           </div>
 
           <div className="border-border border-t pt-3">
-            <p className="text-muted-foreground mb-0.5 text-[10px] tracking-wide uppercase">Total</p>
+            <p className="text-muted-foreground mb-0.5 text-[10px] tracking-wide uppercase">
+              Total
+            </p>
             <p
               className={`font-mono text-2xl font-bold tabular-nums ${!winnerIsUpfront ? "text-green-700" : ""}`}
             >
@@ -189,7 +193,9 @@ export default function FeeOrUpfront(): JSX.Element {
 
       <p className="text-muted-foreground text-center text-xs">
         {winnerIsUpfront ? "Upfront" : "Per-transaction"} saves{" "}
-        <span className="text-foreground font-mono font-semibold">${result.savings.toFixed(2)}</span>
+        <span className="text-foreground font-mono font-semibold">
+          ${result.savings.toFixed(2)}
+        </span>
       </p>
 
       {/* Breakdown table */}

--- a/apps/labyrinth/app/routes/challenges.red-badger.tsx
+++ b/apps/labyrinth/app/routes/challenges.red-badger.tsx
@@ -565,7 +565,9 @@ function PuzzleBar({
         </span>
       )}
       {victory && <span className="font-semibold text-green-600">Victory! 🎉</span>}
-      {!victory && <span className="text-muted-foreground/60 text-xs">Land your robot on the ★</span>}
+      {!victory && (
+        <span className="text-muted-foreground/60 text-xs">Land your robot on the ★</span>
+      )}
       <button
         onClick={() => dispatch({ type: "NEW_PUZZLE" })}
         className="text-muted-foreground hover:text-foreground ml-auto font-mono text-xs underline underline-offset-2"
@@ -697,7 +699,9 @@ export default function RedBadger() {
             </div>
           )}
           {!state.pendingPos && (
-            <div className="text-muted-foreground/60 text-xs">← Click a cell to place your robot</div>
+            <div className="text-muted-foreground/60 text-xs">
+              ← Click a cell to place your robot
+            </div>
           )}
 
           <CommandBuilder cmdInput={state.cmdInput} phase={state.phase} dispatch={dispatch} />

--- a/apps/labyrinth/app/routes/challenges.search-studio.tsx
+++ b/apps/labyrinth/app/routes/challenges.search-studio.tsx
@@ -163,7 +163,9 @@ function ResultRow({
             {highlightText(result.subtitle, query)}
           </span>
           <span className="text-muted-foreground/40 text-[11px]">·</span>
-          <span className="text-muted-foreground/70 text-[12px] tabular-nums">{publishedLabel}</span>
+          <span className="text-muted-foreground/70 text-[12px] tabular-nums">
+            {publishedLabel}
+          </span>
           {result.location && (
             <>
               <span className="text-muted-foreground/40 text-[11px]">·</span>
@@ -238,7 +240,9 @@ function FilterPill({
       onClick={onClick}
       className={[
         "inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-[13px] font-medium transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-        active ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:text-foreground hover:bg-muted",
+        active
+          ? "bg-primary text-primary-foreground"
+          : "text-muted-foreground hover:text-foreground hover:bg-muted",
       ].join(" ")}
     >
       {children}
@@ -350,7 +354,9 @@ export default function SearchStudio() {
                 All
                 {totalResults > 0 && (
                   <span
-                    className={kindFilter === "all" ? "text-foreground/60" : "text-muted-foreground/60"}
+                    className={
+                      kindFilter === "all" ? "text-foreground/60" : "text-muted-foreground/60"
+                    }
                   >
                     {totalResults.toLocaleString()}
                   </span>
@@ -367,7 +373,9 @@ export default function SearchStudio() {
                 Films
                 {kindCounts.movie > 0 && (
                   <span
-                    className={kindFilter === "movie" ? "text-foreground/60" : "text-muted-foreground/60"}
+                    className={
+                      kindFilter === "movie" ? "text-foreground/60" : "text-muted-foreground/60"
+                    }
                   >
                     {kindCounts.movie.toLocaleString()}
                   </span>
@@ -383,7 +391,11 @@ export default function SearchStudio() {
                 <LucideTv className="h-3.5 w-3.5" />
                 TV
                 {kindCounts.tv > 0 && (
-                  <span className={kindFilter === "tv" ? "text-foreground/60" : "text-muted-foreground/60"}>
+                  <span
+                    className={
+                      kindFilter === "tv" ? "text-foreground/60" : "text-muted-foreground/60"
+                    }
+                  >
                     {kindCounts.tv.toLocaleString()}
                   </span>
                 )}
@@ -522,7 +534,9 @@ export default function SearchStudio() {
                     <LucideChevronLeft className="h-4 w-4" />
                     Previous
                   </button>
-                  <span className="text-muted-foreground/60 text-[12px] tabular-nums">Page {page}</span>
+                  <span className="text-muted-foreground/60 text-[12px] tabular-nums">
+                    Page {page}
+                  </span>
                   <button
                     type="button"
                     onClick={() => setPage((p) => (data?.hasNext ? p + 1 : p))}

--- a/apps/labyrinth/app/routes/covid.$countryCode.outlier-detection.tsx
+++ b/apps/labyrinth/app/routes/covid.$countryCode.outlier-detection.tsx
@@ -183,12 +183,16 @@ export default function OutlierDetectionPage() {
                         <Badge variant={outlierBadgeVariant(outlier.severity)}>
                           {outlier.severity}
                         </Badge>
-                        <span className="text-muted-foreground text-xs capitalize">{outlier.type}</span>
+                        <span className="text-muted-foreground text-xs capitalize">
+                          {outlier.type}
+                        </span>
                         <span className="text-muted-foreground text-xs">
                           {new Date(outlier.date).toLocaleDateString()}
                         </span>
                       </div>
-                      <p className="text-muted-foreground truncate text-xs">{outlier.description}</p>
+                      <p className="text-muted-foreground truncate text-xs">
+                        {outlier.description}
+                      </p>
                     </div>
                     <div className="shrink-0 text-right">
                       <p className="text-foreground text-sm font-light tabular-nums">

--- a/apps/labyrinth/app/routes/covid.$countryCode.pandemic-waves.tsx
+++ b/apps/labyrinth/app/routes/covid.$countryCode.pandemic-waves.tsx
@@ -87,7 +87,9 @@ export default function PandemicWavesPage() {
       {isLoading && <Spinner />}
 
       {isError && (
-        <p className="text-muted-foreground py-4 text-sm">Failed to load wave data. Please try again.</p>
+        <p className="text-muted-foreground py-4 text-sm">
+          Failed to load wave data. Please try again.
+        </p>
       )}
 
       {data?.waves && (

--- a/apps/labyrinth/app/routes/covid.$countryCode.seasonal-patterns.tsx
+++ b/apps/labyrinth/app/routes/covid.$countryCode.seasonal-patterns.tsx
@@ -199,7 +199,9 @@ export default function SeasonalPatternsPage() {
                   <div key={insight.pattern} className="border-border border-l-2 py-0.5 pl-4">
                     <p className="text-foreground text-sm font-medium">{insight.pattern}</p>
                     <p className="text-muted-foreground mt-0.5 text-xs">{insight.description}</p>
-                    <p className="text-muted-foreground mt-1 text-xs">{insight.strength}% strength</p>
+                    <p className="text-muted-foreground mt-1 text-xs">
+                      {insight.strength}% strength
+                    </p>
                   </div>
                 ))}
               </div>

--- a/apps/labyrinth/app/routes/covid.$countryCode.tsx
+++ b/apps/labyrinth/app/routes/covid.$countryCode.tsx
@@ -68,7 +68,9 @@ export default function CovidPage() {
   if (!timeSeriesData || timeSeriesData.length === 0) {
     return (
       <div className="ui-flat-card text-center">
-        <p className="text-muted-foreground text-sm">No COVID data available for the selected country.</p>
+        <p className="text-muted-foreground text-sm">
+          No COVID data available for the selected country.
+        </p>
       </div>
     );
   }

--- a/apps/labyrinth/app/routes/experiments.calendar.tsx
+++ b/apps/labyrinth/app/routes/experiments.calendar.tsx
@@ -172,7 +172,7 @@ export default function CalendarExperiment() {
             <p className="ui-data-label mb-1">Time, as it is lived</p>
             <h1 className="text-xl font-semibold tracking-tight">Your day in one stream.</h1>
           </div>
-          <p className="text-xs text-muted-foreground hidden pt-1 text-right sm:block">
+          <p className="text-muted-foreground hidden pt-1 text-right text-xs sm:block">
             Calendar experiment
           </p>
         </header>

--- a/apps/labyrinth/app/routes/experiments.glass.tsx
+++ b/apps/labyrinth/app/routes/experiments.glass.tsx
@@ -106,7 +106,10 @@ export default function ExperimentsGlass() {
               ).map(({ channel, color, label }) => (
                 <div key={channel} className="space-y-2">
                   <div className="flex items-center justify-between">
-                    <Label htmlFor={channel} className="text-muted-foreground flex items-center gap-2">
+                    <Label
+                      htmlFor={channel}
+                      className="text-muted-foreground flex items-center gap-2"
+                    >
                       <span className={cn("inline-block size-2 rounded-full", color)} />
                       {label}
                     </Label>

--- a/apps/labyrinth/app/routes/faq.tsx
+++ b/apps/labyrinth/app/routes/faq.tsx
@@ -19,15 +19,15 @@ export default function Faq() {
       {/* Hero */}
       <section className="section section-hero">
         <h1 className="display-1 text-foreground max-w-4xl">{copy.title}</h1>
-        <p className="text-base text-muted-foreground max-w-2xl">{copy.meta.description}</p>
+        <p className="text-muted-foreground max-w-2xl text-base">{copy.meta.description}</p>
       </section>
 
       {/* Q&A — editorial stack */}
       <section className="section gap-12">
         {copy.items.map((faq) => (
           <article key={faq.question} className="flex max-w-3xl flex-col gap-3">
-            <h2 className="text-lg font-semibold tracking-tight text-foreground">{faq.question}</h2>
-            <p className="text-base text-muted-foreground">{faq.answer}</p>
+            <h2 className="text-foreground text-lg font-semibold tracking-tight">{faq.question}</h2>
+            <p className="text-muted-foreground text-base">{faq.answer}</p>
           </article>
         ))}
       </section>
@@ -35,7 +35,7 @@ export default function Faq() {
       {/* Close */}
       <section className="section section-hero border-b-0">
         <h2 className="display-2 text-foreground max-w-3xl">{t.services.cta.title}</h2>
-        <p className="text-base text-muted-foreground max-w-xl">{t.services.cta.body}</p>
+        <p className="text-muted-foreground max-w-xl text-base">{t.services.cta.body}</p>
         <div className="flex flex-wrap items-center gap-6 pt-2">
           <Button asChild>
             <a href={BOOK_CALL_URL} target="_blank" rel="noreferrer">
@@ -45,7 +45,7 @@ export default function Faq() {
           <Link
             to="/services"
             prefetch="intent"
-            className="text-sm text-foreground underline-offset-4 hover:underline"
+            className="text-foreground text-sm underline-offset-4 hover:underline"
           >
             {t.home.services.cta}
           </Link>

--- a/apps/labyrinth/app/routes/games/realitea/route.tsx
+++ b/apps/labyrinth/app/routes/games/realitea/route.tsx
@@ -223,8 +223,10 @@ type ErrorBoundaryProps = { error: Error };
 export function ErrorBoundary({ error }: ErrorBoundaryProps) {
   return (
     <div className="mx-auto flex w-full max-w-2xl flex-1 flex-col items-center justify-center gap-3 px-4 text-center">
-      <p className="text-xs text-muted-foreground tracking-[0.15em] uppercase">Something went wrong</p>
-      <p className="text-xs text-muted-foreground">
+      <p className="text-muted-foreground text-xs tracking-[0.15em] uppercase">
+        Something went wrong
+      </p>
+      <p className="text-muted-foreground text-xs">
         {error.message || "The RealiTea puzzle couldn't load. Try refreshing the page."}
       </p>
       <Button asChild variant="default" className="mt-2">
@@ -400,7 +402,7 @@ export default function RealiTeaRoute() {
           <CardContent className="flex flex-col gap-4">
             <div>
               <p className="ui-eyebrow">{game.isSolved ? "The Story" : "The puzzle ended"}</p>
-              <p className="text-xs mt-1">{currentPuzzle.detail.toLocaleLowerCase()}</p>
+              <p className="mt-1 text-xs">{currentPuzzle.detail.toLocaleLowerCase()}</p>
             </div>
             <div className="flex justify-end gap-2">
               <Button aria-label="Share result" onClick={share} type="button" variant="secondary">

--- a/apps/labyrinth/app/routes/health/medication.tsx
+++ b/apps/labyrinth/app/routes/health/medication.tsx
@@ -120,7 +120,9 @@ export default function MedicationPen(): JSX.Element {
             {partialDose !== null && (
               <li className="bg-muted/50 border-muted-foreground/20 flex items-center justify-between rounded-md border border-dashed px-4 py-2">
                 <span className="font-medium">Week {Math.floor(totalWeeks) + 1} (partial)</span>
-                <span className="text-muted-foreground tabular-nums">{partialDose.toFixed(1)} mg</span>
+                <span className="text-muted-foreground tabular-nums">
+                  {partialDose.toFixed(1)} mg
+                </span>
               </li>
             )}
           </ul>

--- a/apps/labyrinth/app/routes/home.tsx
+++ b/apps/labyrinth/app/routes/home.tsx
@@ -16,8 +16,8 @@ export function meta(): Array<{
 function Teaser({ title, to }: { title: string; to: string }) {
   return (
     <section className="section section-compact underline-offset-4 hover:cursor-pointer hover:underline">
-      <Link to={to} prefetch="intent" className="text-sm flex justify-between">
-        <h2 className="text-xl font-semibold tracking-tight text-foreground font-bold">{title}</h2>
+      <Link to={to} prefetch="intent" className="flex justify-between text-sm">
+        <h2 className="text-foreground text-xl font-bold font-semibold tracking-tight">{title}</h2>
         <LucideArrowBigRight className="text-accent" aria-hidden="true" />
       </Link>
     </section>
@@ -62,7 +62,7 @@ export default function Home() {
       <section className="section section-hero md:flex-row md:justify-between">
         <div>
           <HeroHeadline />
-          <p className="text-base text-muted-foreground max-w-2xl">{t.home.hero.subtitle}</p>
+          <p className="text-muted-foreground max-w-2xl text-base">{t.home.hero.subtitle}</p>
         </div>
         <div className="flex flex-wrap items-center gap-6 pt-2">
           <Button asChild variant="default">

--- a/apps/labyrinth/app/routes/manifesto.tsx
+++ b/apps/labyrinth/app/routes/manifesto.tsx
@@ -34,7 +34,7 @@ export default function Manifesto() {
       {/* Hero */}
       <section className="section section-hero">
         <ManifestoHeroHeadline />
-        <p className="text-base text-muted-foreground max-w-2xl">{copy.hero.body}</p>
+        <p className="text-muted-foreground max-w-2xl text-base">{copy.hero.body}</p>
       </section>
 
       {/* Tenets — single-column editorial list, one idea at a time */}
@@ -45,12 +45,14 @@ export default function Manifesto() {
               key={tenet.title}
               className="grid gap-3 sm:grid-cols-[minmax(0,4rem)_1fr] sm:gap-10"
             >
-              <span className="text-sm text-muted-foreground tabular-nums">
+              <span className="text-muted-foreground text-sm tabular-nums">
                 {String(index + 1).padStart(2, "0")}
               </span>
               <div className="flex max-w-3xl flex-col gap-3">
-                <h2 className="text-lg font-semibold tracking-tight text-foreground">{tenet.title}</h2>
-                <p className="text-base text-muted-foreground">{tenet.description}</p>
+                <h2 className="text-foreground text-lg font-semibold tracking-tight">
+                  {tenet.title}
+                </h2>
+                <p className="text-muted-foreground text-base">{tenet.description}</p>
               </div>
             </li>
           ))}

--- a/apps/labyrinth/app/routes/projects.$slug.tsx
+++ b/apps/labyrinth/app/routes/projects.$slug.tsx
@@ -25,7 +25,7 @@ export default function ProjectDetail() {
           <Link
             to="/projects"
             prefetch="intent"
-            className="text-sm text-accent min-h-11 w-fit content-center underline underline-offset-4 outline-none"
+            className="text-accent min-h-11 w-fit content-center text-sm underline underline-offset-4 outline-none"
           >
             ← {t.projects.page.back}
           </Link>
@@ -47,7 +47,7 @@ export default function ProjectDetail() {
           <Link
             to="/projects"
             prefetch="intent"
-            className="text-sm text-muted-foreground hover:text-foreground min-h-11 w-fit content-center outline-none"
+            className="text-muted-foreground hover:text-foreground min-h-11 w-fit content-center text-sm outline-none"
           >
             ← {t.projects.page.title}
           </Link>
@@ -90,20 +90,26 @@ export default function ProjectDetail() {
       />
 
       <section className="section">
-        <h2 className="text-xl font-semibold tracking-tight text-foreground">{t.projects.page.problem}</h2>
-        <p className="text-base text-muted-foreground max-w-2xl">{project.problem}</p>
+        <h2 className="text-foreground text-xl font-semibold tracking-tight">
+          {t.projects.page.problem}
+        </h2>
+        <p className="text-muted-foreground max-w-2xl text-base">{project.problem}</p>
       </section>
 
       {project.solution ? (
         <section className="section">
-          <h2 className="text-xl font-semibold tracking-tight text-foreground">{t.projects.page.solution}</h2>
-          <p className="text-base text-muted-foreground max-w-2xl">{project.solution}</p>
+          <h2 className="text-foreground text-xl font-semibold tracking-tight">
+            {t.projects.page.solution}
+          </h2>
+          <p className="text-muted-foreground max-w-2xl text-base">{project.solution}</p>
         </section>
       ) : null}
 
       {project.screenshots && project.screenshots.length > 0 ? (
         <section className="section">
-          <h2 className="text-xl font-semibold tracking-tight text-foreground">{t.projects.page.screenshots}</h2>
+          <h2 className="text-foreground text-xl font-semibold tracking-tight">
+            {t.projects.page.screenshots}
+          </h2>
           <ScrollArea className="-mx-4 gap-4 px-4 md:mx-0 md:px-0" snap="start">
             {project.screenshots.map((src, index) => (
               <a
@@ -131,14 +137,16 @@ export default function ProjectDetail() {
 
       {howItWorks.length > 0 ? (
         <section className="section gap-8">
-          <h2 className="text-xl font-semibold tracking-tight text-foreground">{t.projects.page.howItWorks}</h2>
+          <h2 className="text-foreground text-xl font-semibold tracking-tight">
+            {t.projects.page.howItWorks}
+          </h2>
           <ul className="flex max-w-2xl flex-col gap-3">
             {howItWorks.map((point) => (
               <li key={`${project.slug}-${point}`} className="flex gap-3">
                 <span className="text-accent mt-1" aria-hidden="true">
                   •
                 </span>
-                <span className="text-base text-muted-foreground">{point}</span>
+                <span className="text-muted-foreground text-base">{point}</span>
               </li>
             ))}
           </ul>

--- a/apps/labyrinth/app/routes/projects.tsx
+++ b/apps/labyrinth/app/routes/projects.tsx
@@ -26,7 +26,9 @@ export default function Projects() {
       {projectSections.map((section) => {
         return (
           <section key={section.category} className="layout-stack">
-            <h2 className="text-xl font-semibold tracking-tight text-foreground border-border border-b pb-3">{section.label}</h2>
+            <h2 className="text-foreground border-border border-b pb-3 text-xl font-semibold tracking-tight">
+              {section.label}
+            </h2>
             <div className="border-border divide-border-border divide-y border-b">
               {section.projects.map((project) => (
                 <div key={project.slug} className="list-row group">
@@ -43,10 +45,12 @@ export default function Projects() {
                       />
                     ) : null}
                     <div className="flex min-w-0 flex-1 flex-col gap-1">
-                      <h3 className="text-xl font-semibold tracking-tight text-foreground group-hover:text-accent transition-colors motion-reduce:transition-none">
+                      <h3 className="text-foreground group-hover:text-accent text-xl font-semibold tracking-tight transition-colors motion-reduce:transition-none">
                         {project.name}
                       </h3>
-                      <p className="text-sm text-muted-foreground max-w-2xl">{project.shortDescription}</p>
+                      <p className="text-muted-foreground max-w-2xl text-sm">
+                        {project.shortDescription}
+                      </p>
                     </div>
                   </Link>
                 </div>

--- a/apps/labyrinth/app/routes/services.tsx
+++ b/apps/labyrinth/app/routes/services.tsx
@@ -43,7 +43,7 @@ export default function Services() {
           <Link
             to="/work"
             prefetch="intent"
-            className="text-sm text-foreground underline-offset-4 hover:underline"
+            className="text-foreground text-sm underline-offset-4 hover:underline"
           >
             {copy.hero.seeWork}
           </Link>
@@ -53,14 +53,16 @@ export default function Services() {
       {/* Services — editorial catalog, same for every visitor */}
       <section className="section gap-12">
         <div className="flex flex-col gap-3">
-          <h2 className="text-xl font-semibold tracking-tight text-foreground">{copy.services.title}</h2>
-          <p className="text-sm text-muted-foreground max-w-2xl">{copy.services.intro}</p>
+          <h2 className="text-foreground text-xl font-semibold tracking-tight">
+            {copy.services.title}
+          </h2>
+          <p className="text-muted-foreground max-w-2xl text-sm">{copy.services.intro}</p>
         </div>
 
         <div className="flex flex-col gap-16">
           {servicePillars.map((pillar) => (
             <div key={pillar.name} className="flex flex-col gap-8">
-              <h3 className="text-lg font-semibold tracking-tight text-accent">{pillar.name}</h3>
+              <h3 className="text-accent text-lg font-semibold tracking-tight">{pillar.name}</h3>
               <div className="flex flex-col gap-10">
                 {pillar.services.map((service) => (
                   <article
@@ -68,12 +70,14 @@ export default function Services() {
                     id={service.slug}
                     className="grid gap-4 sm:grid-cols-[minmax(0,14rem)_1fr] sm:gap-10"
                   >
-                    <h4 className="subtext-xl font-semibold tracking-tight text-foreground">{service.name}</h4>
+                    <h4 className="subtext-xl text-foreground font-semibold tracking-tight">
+                      {service.name}
+                    </h4>
                     <ul className="flex flex-col gap-2">
                       {service.deliverables.map((item) => (
                         <li key={item.label} className="ui-dash-list-item">
                           <span className="ui-dash-marker">—</span>
-                          <span className="text-sm text-muted-foreground">
+                          <span className="text-muted-foreground text-sm">
                             <span className="text-foreground font-medium">{item.label}:</span>{" "}
                             {item.description}
                           </span>
@@ -91,18 +95,22 @@ export default function Services() {
       {/* Process — quiet, linear, same for everyone */}
       <section className="section gap-10">
         <div className="flex flex-col gap-3">
-          <h2 className="text-xl font-semibold tracking-tight text-foreground">{copy.process.title}</h2>
-          <p className="text-sm text-muted-foreground max-w-2xl">{copy.process.intro}</p>
+          <h2 className="text-foreground text-xl font-semibold tracking-tight">
+            {copy.process.title}
+          </h2>
+          <p className="text-muted-foreground max-w-2xl text-sm">{copy.process.intro}</p>
         </div>
         <ol className="flex flex-col gap-8">
           {t.common.contactSteps.map((step, index) => (
             <li key={step.title} className="grid gap-2 sm:grid-cols-[minmax(0,4rem)_1fr] sm:gap-8">
-              <span className="text-sm text-muted-foreground tabular-nums">
+              <span className="text-muted-foreground text-sm tabular-nums">
                 {String(index + 1).padStart(2, "0")}
               </span>
               <div className="flex flex-col gap-1">
-                <span className="subtext-lg font-semibold tracking-tight text-foreground">{step.title}</span>
-                <span className="text-sm text-muted-foreground">{step.description}</span>
+                <span className="subtext-lg text-foreground font-semibold tracking-tight">
+                  {step.title}
+                </span>
+                <span className="text-muted-foreground text-sm">{step.description}</span>
               </div>
             </li>
           ))}
@@ -112,14 +120,14 @@ export default function Services() {
       {/* Closing CTA */}
       <section className="section section-hero">
         <h2 className="display-2 text-foreground max-w-3xl">{copy.cta.title}</h2>
-        <p className="text-base text-muted-foreground max-w-xl">{copy.cta.body}</p>
+        <p className="text-muted-foreground max-w-xl text-base">{copy.cta.body}</p>
         <div className="flex flex-wrap items-center gap-6 pt-2">
           <Button asChild>
             <a href={BOOK_CALL_URL} target="_blank" rel="noreferrer">
               {t.common.bookCall}
             </a>
           </Button>
-          <p className="text-sm text-muted-foreground">{t.common.replyWithin}</p>
+          <p className="text-muted-foreground text-sm">{t.common.replyWithin}</p>
         </div>
       </section>
 
@@ -127,7 +135,7 @@ export default function Services() {
         <Link
           to="/faq"
           prefetch="intent"
-          className="text-sm text-foreground hover:text-muted-foreground flex items-center gap-2"
+          className="text-foreground hover:text-muted-foreground flex items-center gap-2 text-sm"
         >
           <HelpCircle className="size-4" aria-hidden="true" />
           {t.faq.eyebrow}

--- a/apps/labyrinth/app/routes/tarot.tsx
+++ b/apps/labyrinth/app/routes/tarot.tsx
@@ -115,7 +115,9 @@ export default function TarotRoute() {
 
         {!isHydrated ? (
           <Card className="border-border bg-background border p-8 shadow-sm">
-            <div className="text-muted-foreground py-16 text-center">Preparing today&apos;s ritual...</div>
+            <div className="text-muted-foreground py-16 text-center">
+              Preparing today&apos;s ritual...
+            </div>
           </Card>
         ) : result ? (
           <DailyTarotReadingView result={result} />

--- a/apps/labyrinth/app/routes/theatre-management/components/PLStatement.tsx
+++ b/apps/labyrinth/app/routes/theatre-management/components/PLStatement.tsx
@@ -76,7 +76,9 @@ export function PLStatement({
           <div className="mt-1.5 flex items-center gap-2">
             <span className={cn("size-1.5 rounded-full", healthDot)} />
             <span className={cn("text-xs font-medium", healthTextColor)}>{healthLabel}</span>
-            <span className="text-muted-foreground text-xs">· {(d.margin * 100).toFixed(1)}% margin</span>
+            <span className="text-muted-foreground text-xs">
+              · {(d.margin * 100).toFixed(1)}% margin
+            </span>
           </div>
         </div>
       </CardContent>

--- a/apps/labyrinth/app/routes/theatre-management/components/ProfitRevenueCard.tsx
+++ b/apps/labyrinth/app/routes/theatre-management/components/ProfitRevenueCard.tsx
@@ -52,7 +52,9 @@ export function ProfitRevenueCard({
             </div>
             <div className="mt-1 flex items-center gap-1.5">
               <TrendingUp className="text-muted-foreground size-3" />
-              <span className="text-muted-foreground text-xs">{fmt(d.monthlyVisitors)} visitors</span>
+              <span className="text-muted-foreground text-xs">
+                {fmt(d.monthlyVisitors)} visitors
+              </span>
             </div>
           </div>
         </div>

--- a/apps/labyrinth/app/routes/theatre-management/components/ScreenAllocation.tsx
+++ b/apps/labyrinth/app/routes/theatre-management/components/ScreenAllocation.tsx
@@ -48,7 +48,9 @@ export function ScreenAllocation({
               <span className="ui-data-label">Screen Allocation</span>
               <Clapperboard className="text-muted-foreground size-4" />
             </div>
-            <p className="text-muted-foreground mt-1 text-xs">Roster your screens like a weekly lineup.</p>
+            <p className="text-muted-foreground mt-1 text-xs">
+              Roster your screens like a weekly lineup.
+            </p>
           </div>
           <div className="text-right">
             <div className="text-foreground font-mono text-sm font-semibold tabular-nums">

--- a/apps/labyrinth/app/routes/theatre-management/route.tsx
+++ b/apps/labyrinth/app/routes/theatre-management/route.tsx
@@ -42,7 +42,9 @@ export default function TheaterEconomics() {
         <div className="bg-border h-4 w-px" />
         <div>
           <div className="flex items-center gap-2">
-            <h1 className="text-foreground text-lg font-semibold tracking-tight">Theater P&amp;L</h1>
+            <h1 className="text-foreground text-lg font-semibold tracking-tight">
+              Theater P&amp;L
+            </h1>
             <Badge variant="secondary" className="text-[10px]">
               Beta
             </Badge>

--- a/apps/labyrinth/app/routes/work.$slug.tsx
+++ b/apps/labyrinth/app/routes/work.$slug.tsx
@@ -37,7 +37,7 @@ export default function WorkSlug() {
           <Link
             to="/work"
             prefetch="intent"
-            className="text-sm text-muted-foreground hover:text-foreground min-h-11 w-fit content-center outline-none"
+            className="text-muted-foreground hover:text-foreground min-h-11 w-fit content-center text-sm outline-none"
           >
             ← {copy.backToWork}
           </Link>
@@ -66,20 +66,24 @@ export default function WorkSlug() {
 
       {/* What I did */}
       <section className="section">
-        <h2 className="text-xl font-semibold tracking-tight text-foreground">{proof.whatWeDidLabel}</h2>
-        <p className="text-base text-muted-foreground max-w-2xl">{snapshot.whatWeDid}</p>
+        <h2 className="text-foreground text-xl font-semibold tracking-tight">
+          {proof.whatWeDidLabel}
+        </h2>
+        <p className="text-muted-foreground max-w-2xl text-base">{snapshot.whatWeDid}</p>
       </section>
 
       {/* Approach */}
       <section className="section gap-8">
-        <h2 className="text-xl font-semibold tracking-tight text-foreground">{copy.approachTitle}</h2>
+        <h2 className="text-foreground text-xl font-semibold tracking-tight">
+          {copy.approachTitle}
+        </h2>
         <ol className="flex flex-col gap-8">
           {snapshot.approach.map((step, index) => (
             <li key={step} className="grid gap-2 sm:grid-cols-[minmax(0,4rem)_1fr] sm:gap-8">
-              <span className="text-sm text-muted-foreground tabular-nums">
+              <span className="text-muted-foreground text-sm tabular-nums">
                 {String(index + 1).padStart(2, "0")}
               </span>
-              <span className="text-base text-foreground max-w-2xl">{step}</span>
+              <span className="text-foreground max-w-2xl text-base">{step}</span>
             </li>
           ))}
         </ol>
@@ -87,12 +91,14 @@ export default function WorkSlug() {
 
       {/* Outcomes — pull quotes, not metric tiles */}
       <section className="section gap-10 md:gap-12">
-        <h2 className="text-xl font-semibold tracking-tight text-foreground">{proof.outcomeLabel}</h2>
+        <h2 className="text-foreground text-xl font-semibold tracking-tight">
+          {proof.outcomeLabel}
+        </h2>
         <div className="flex flex-col gap-12">
           {snapshot.outcomes.map((outcome) => (
             <div key={outcome.label} className="flex max-w-3xl flex-col gap-1">
               <p className="display-2 text-accent">{outcome.value}</p>
-              <p className="text-base font-semibold text-foreground">{outcome.label}</p>
+              <p className="text-foreground text-base font-semibold">{outcome.label}</p>
             </div>
           ))}
         </div>
@@ -113,7 +119,7 @@ export default function WorkSlug() {
       {/* Close CTA */}
       <section className="section gap-6 border-b-0 py-16 md:py-20">
         <h2 className="display-2 text-foreground max-w-3xl">{copy.nextCta.title}</h2>
-        <p className="text-base text-muted-foreground max-w-xl">{copy.nextCta.body}</p>
+        <p className="text-muted-foreground max-w-xl text-base">{copy.nextCta.body}</p>
         <div className="flex flex-wrap items-center gap-6 pt-2">
           <Button asChild>
             <a href={BOOK_CALL_URL} target="_blank" rel="noreferrer">
@@ -123,7 +129,7 @@ export default function WorkSlug() {
           <Link
             to="/services"
             prefetch="intent"
-            className="text-sm text-foreground underline-offset-4 hover:underline"
+            className="text-foreground text-sm underline-offset-4 hover:underline"
           >
             {t.home.services.cta}
           </Link>

--- a/apps/labyrinth/app/routes/work.tsx
+++ b/apps/labyrinth/app/routes/work.tsx
@@ -38,13 +38,13 @@ export default function Work() {
                   />
                 ) : null}
                 <div className="flex min-w-0 flex-1 flex-col gap-1">
-                  <span className="text-xs text-muted-foreground tracking-wide uppercase">
+                  <span className="text-muted-foreground text-xs tracking-wide uppercase">
                     {snapshot.industry}
                   </span>
-                  <h3 className="text-xl font-semibold tracking-tight text-foreground group-hover:text-accent transition-colors motion-reduce:transition-none">
+                  <h3 className="text-foreground group-hover:text-accent text-xl font-semibold tracking-tight transition-colors motion-reduce:transition-none">
                     {snapshot.client}
                   </h3>
-                  <p className="text-sm text-muted-foreground max-w-2xl">{snapshot.description}</p>
+                  <p className="text-muted-foreground max-w-2xl text-sm">{snapshot.description}</p>
                 </div>
               </Link>
             </div>

--- a/apps/voy/package.json
+++ b/apps/voy/package.json
@@ -8,7 +8,7 @@
     "server": "node server.js",
     "web": "webpack serve --mode development",
     "build": "webpack --mode production",
-    "test": "jest --watchAll"
+    "test": "jest"
   },
   "keywords": [
     "coding-test",

--- a/apps/voy/src/solution.js
+++ b/apps/voy/src/solution.js
@@ -8,6 +8,7 @@ function calculatePenDuration(weeklyDosages, penCapacity) {
       remaining = remaining - dosage;
     } else {
       weeks += remaining / dosage;
+      break;
     }
   }
 

--- a/apps/voy/src/solution.test.js
+++ b/apps/voy/src/solution.test.js
@@ -12,4 +12,9 @@ describe("calculatePenDuration", () => {
     expect(calculatePenDuration([50, 50], 100)).toBe(2);
     expect(calculatePenDuration([10, 20, 30, 15], 100)).toBe(4);
   });
+
+  test("should stop counting once the pen runs out, ignoring later dosages", () => {
+    const result = calculatePenDuration([30, 30, 30, 30, 30], 100);
+    expect(result).toBeCloseTo(3.333, 2);
+  });
 });

--- a/apps/voy/src/solution.test.js
+++ b/apps/voy/src/solution.test.js
@@ -3,13 +3,13 @@ const { calculatePenDuration } = require("./solution");
 describe("calculatePenDuration", () => {
 
   test("should calculate partial weeks when medication runs out mid-week", () => {
-    expect(calculatePenDuration([25, 25, 25, 25])).toBe(4);
-    const result = calculatePenDuration([30, 30, 30, 30]);
+    expect(calculatePenDuration([25, 25, 25, 25], 100)).toBe(4);
+    const result = calculatePenDuration([30, 30, 30, 30], 100);
     expect(result).toBeCloseTo(3.333, 2);
   });
 
   test("should calculate exact usage correctly", () => {
-    expect(calculatePenDuration([50, 50])).toBe(2);
-    expect(calculatePenDuration([10, 20, 30, 15])).toBe(4);
+    expect(calculatePenDuration([50, 50], 100)).toBe(2);
+    expect(calculatePenDuration([10, 20, 30, 15], 100)).toBe(4);
   });
 });

--- a/packages/ui/src/animations.css
+++ b/packages/ui/src/animations.css
@@ -1,19 +1,96 @@
-@keyframes accordion-down { from { height: 0; } to { height: var(--accordion-content-height); } }
-@keyframes accordion-up { from { height: var(--accordion-content-height); } to { height: 0; } }
-@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
-@keyframes fade-out { from { opacity: 1; } to { opacity: 0; } }
-@keyframes zoom-in { from { opacity: 0; transform: scale(0.95); } to { opacity: 1; transform: scale(1); } }
-@keyframes zoom-out { from { opacity: 1; transform: scale(1); } to { opacity: 0; transform: scale(0.95); } }
+@keyframes accordion-down {
+  from {
+    height: 0;
+  }
+  to {
+    height: var(--accordion-content-height);
+  }
+}
+@keyframes accordion-up {
+  from {
+    height: var(--accordion-content-height);
+  }
+  to {
+    height: 0;
+  }
+}
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+@keyframes zoom-in {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+@keyframes zoom-out {
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+}
 
-.animate-in { animation: fade-in 150ms ease-out, zoom-in 150ms ease-out; }
-.animate-out { animation: fade-out 120ms ease-in, zoom-out 120ms ease-in; }
-.fade-in-0 { animation-name: fade-in; }
-.fade-out-0 { animation-name: fade-out; }
-.zoom-in-95 { animation-name: zoom-in; }
-.zoom-out-95 { animation-name: zoom-out; }
-.data-open\:animate-in[data-open], .data-open\:animate-in[data-state="open"] { animation: fade-in 150ms ease-out, zoom-in 150ms ease-out; }
-.data-closed\:animate-out[data-closed], .data-closed\:animate-out[data-state="closed"] { animation: fade-out 120ms ease-in, zoom-out 120ms ease-in; }
+.animate-in {
+  animation:
+    fade-in 150ms ease-out,
+    zoom-in 150ms ease-out;
+}
+.animate-out {
+  animation:
+    fade-out 120ms ease-in,
+    zoom-out 120ms ease-in;
+}
+.fade-in-0 {
+  animation-name: fade-in;
+}
+.fade-out-0 {
+  animation-name: fade-out;
+}
+.zoom-in-95 {
+  animation-name: zoom-in;
+}
+.zoom-out-95 {
+  animation-name: zoom-out;
+}
+.data-open\:animate-in[data-open],
+.data-open\:animate-in[data-state="open"] {
+  animation:
+    fade-in 150ms ease-out,
+    zoom-in 150ms ease-out;
+}
+.data-closed\:animate-out[data-closed],
+.data-closed\:animate-out[data-state="closed"] {
+  animation:
+    fade-out 120ms ease-in,
+    zoom-out 120ms ease-in;
+}
 
 @media (prefers-reduced-motion: reduce) {
-  .animate-in, .animate-out, [data-open], [data-closed] { animation: none !important; }
+  .animate-in,
+  .animate-out,
+  [data-open],
+  [data-closed] {
+    animation: none !important;
+  }
 }

--- a/packages/ui/src/components/data-display/accordion.tsx
+++ b/packages/ui/src/components/data-display/accordion.tsx
@@ -4,11 +4,22 @@ import * as React from "react";
 
 import { cn } from "../../lib/utils";
 
-function Accordion({ type, collapsible: _collapsible, ...props }: React.ComponentProps<typeof AccordionPrimitive.Root> & {
+function Accordion({
+  type,
+  collapsible: _collapsible,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Root> & {
   type?: "single" | "multiple";
   collapsible?: boolean;
 }) {
-  return <AccordionPrimitive.Root data-slot="accordion" multiple={type === "multiple"} {...props} className="w-full" />;
+  return (
+    <AccordionPrimitive.Root
+      data-slot="accordion"
+      multiple={type === "multiple"}
+      {...props}
+      className="w-full"
+    />
+  );
 }
 
 function AccordionItem({
@@ -18,10 +29,7 @@ function AccordionItem({
   return (
     <AccordionPrimitive.Item
       data-slot="accordion-item"
-      className={cn(
-        "mb-2 overflow-hidden rounded-md border last:mb-0",
-        className,
-      )}
+      className={cn("mb-2 overflow-hidden rounded-md border last:mb-0", className)}
       {...props}
     />
   );

--- a/packages/ui/src/components/data-display/accordion.tsx
+++ b/packages/ui/src/components/data-display/accordion.tsx
@@ -7,6 +7,7 @@ import { cn } from "../../lib/utils";
 function Accordion({
   type,
   collapsible: _collapsible,
+  className,
   ...props
 }: React.ComponentProps<typeof AccordionPrimitive.Root> & {
   type?: "single" | "multiple";
@@ -17,7 +18,7 @@ function Accordion({
       data-slot="accordion"
       multiple={type === "multiple"}
       {...props}
-      className="w-full"
+      className={cn("w-full", className)}
     />
   );
 }

--- a/packages/ui/src/components/data-display/table.tsx
+++ b/packages/ui/src/components/data-display/table.tsx
@@ -37,11 +37,7 @@ TableFooter.displayName = "TableFooter";
 
 const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
   ({ className, ...props }, ref) => (
-    <tr
-      ref={ref}
-      className={cn("data-[state=selected]:bg-muted border-b", className)}
-      {...props}
-    />
+    <tr ref={ref} className={cn("data-[state=selected]:bg-muted border-b", className)} {...props} />
   ),
 );
 TableRow.displayName = "TableRow";
@@ -53,7 +49,7 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      "h-9 px-3 text-left align-middle text-xs font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      "text-muted-foreground h-9 px-3 text-left align-middle text-xs font-medium [&:has([role=checkbox])]:pr-0",
       className,
     )}
     {...props}
@@ -77,7 +73,7 @@ const TableCaption = React.forwardRef<
   HTMLTableCaptionElement,
   React.HTMLAttributes<HTMLTableCaptionElement>
 >(({ className, ...props }, ref) => (
-  <caption ref={ref} className={cn("mt-4 text-sm text-muted-foreground", className)} {...props} />
+  <caption ref={ref} className={cn("text-muted-foreground mt-4 text-sm", className)} {...props} />
 ));
 TableCaption.displayName = "TableCaption";
 

--- a/packages/ui/src/components/feedback/empty-state.tsx
+++ b/packages/ui/src/components/feedback/empty-state.tsx
@@ -37,9 +37,9 @@ export function EmptyState({
     <section
       className={cn(
         "rounded-lg px-5 py-8",
-        variant === "default" && "border bg-card",
-        variant === "dashed" && "border bg-card border-dashed",
-        variant === "search" && "border bg-muted border-dashed",
+        variant === "default" && "bg-card border",
+        variant === "dashed" && "bg-card border border-dashed",
+        variant === "search" && "bg-muted border border-dashed",
         variant === "quiet" && "bg-surface",
         centered
           ? cn(
@@ -51,13 +51,23 @@ export function EmptyState({
       )}
     >
       {icon ? (
-        <div className="text-muted-foreground mb-3 flex size-11 items-center justify-center" aria-hidden>
+        <div
+          className="text-muted-foreground mb-3 flex size-11 items-center justify-center"
+          aria-hidden
+        >
           {icon}
         </div>
       ) : null}
       <div className={cn("space-y-2", centered && "max-w-[34ch]")}>
-        <h2 className={cn("text-foreground font-semibold tracking-tight", large ? "text-lg" : "text-base")}>{title}</h2>
-        {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
+        <h2
+          className={cn(
+            "text-foreground font-semibold tracking-tight",
+            large ? "text-lg" : "text-base",
+          )}
+        >
+          {title}
+        </h2>
+        {description ? <p className="text-muted-foreground text-sm">{description}</p> : null}
       </div>
       {children ? <div className="mt-3">{children}</div> : null}
       {action ? <div className="mt-4">{action}</div> : null}

--- a/packages/ui/src/components/feedback/update-guard.tsx
+++ b/packages/ui/src/components/feedback/update-guard.tsx
@@ -240,7 +240,7 @@ function UpdateGuardClient({
                 {copy?.refreshButton ?? "Refresh"}
               </button>
             ) : null}
-          <button type="button" onClick={closePrompt} className="text-muted-foreground text-sm">
+            <button type="button" onClick={closePrompt} className="text-muted-foreground text-sm">
               {copy?.closeButton ?? "Close"}
             </button>
           </div>

--- a/packages/ui/src/components/forms/calendar.tsx
+++ b/packages/ui/src/components/forms/calendar.tsx
@@ -24,7 +24,8 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
           "inline-flex size-8 p-2 items-center justify-center rounded-full border bg-background text-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50",
         month_grid: "w-full border-collapse",
         weekdays: "flex",
-        weekday: "flex size-8 items-center justify-center text-[0.8rem] font-normal text-muted-foreground",
+        weekday:
+          "flex size-8 items-center justify-center text-[0.8rem] font-normal text-muted-foreground",
         week: "mt-1 flex w-full",
         day: "relative size-8 p-0 text-center text-lg focus-within:z-20",
         day_button:
@@ -34,9 +35,11 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
         today: "[&>button]:bg-primary [&>button]:text-primary-foreground",
         outside: "text-muted-foreground [&>button]:text-muted-foreground",
         disabled: "text-muted-foreground opacity-50",
-        range_start: "rounded-l-md bg-primary [&>button]:bg-primary [&>button]:text-primary-foreground",
+        range_start:
+          "rounded-l-md bg-primary [&>button]:bg-primary [&>button]:text-primary-foreground",
         range_middle: "bg-primary [&>button]:rounded-none [&>button]:text-primary-foreground",
-        range_end: "rounded-r-md bg-primary [&>button]:bg-primary [&>button]:text-primary-foreground",
+        range_end:
+          "rounded-r-md bg-primary [&>button]:bg-primary [&>button]:text-primary-foreground",
         hidden: "invisible",
         ...classNames,
       }}

--- a/packages/ui/src/components/forms/field.tsx
+++ b/packages/ui/src/components/forms/field.tsx
@@ -29,7 +29,7 @@ function Field({ label, helpText, error, required, children, id: externalId }: F
         <label
           htmlFor={id}
           className={cn(
-            "text-sm text-foreground font-medium",
+            "text-foreground text-sm font-medium",
             required && "after:text-destructive after:ml-0.5 after:content-['*']",
           )}
         >
@@ -50,11 +50,11 @@ function Field({ label, helpText, error, required, children, id: externalId }: F
         : children}
 
       {error ? (
-        <p id={errorId} role="alert" className="text-sm text-destructive">
+        <p id={errorId} role="alert" className="text-destructive text-sm">
           {error}
         </p>
       ) : helpText ? (
-        <p id={descId} className="text-sm text-muted-foreground">
+        <p id={descId} className="text-muted-foreground text-sm">
           {helpText}
         </p>
       ) : null}

--- a/packages/ui/src/components/forms/input.tsx
+++ b/packages/ui/src/components/forms/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground bg-background focus-visible:ring-ring h-9 w-full min-w-0 rounded-md border border-input px-3 py-1 text-base transition-colors file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground bg-background focus-visible:ring-ring border-input h-9 w-full min-w-0 rounded-md border px-3 py-1 text-base transition-colors file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "aria-invalid:ring-destructive/20 aria-invalid:border-destructive",
         className,
       )}

--- a/packages/ui/src/components/forms/passkey-management.tsx
+++ b/packages/ui/src/components/forms/passkey-management.tsx
@@ -69,10 +69,10 @@ export function PasskeyManagement({
     <section aria-labelledby="passkey-heading" className="space-y-4">
       <div className="flex items-center justify-between">
         <div>
-          <h2 id="passkey-heading" className="text-sm font-medium text-foreground">
+          <h2 id="passkey-heading" className="text-foreground text-sm font-medium">
             Passkeys
           </h2>
-          <p className="text-sm text-muted-foreground">
+          <p className="text-muted-foreground text-sm">
             Sign in without a password using biometrics or a security key.
           </p>
         </div>

--- a/packages/ui/src/components/forms/select.tsx
+++ b/packages/ui/src/components/forms/select.tsx
@@ -4,7 +4,10 @@ import * as React from "react";
 
 import { cn } from "../../lib/utils";
 
-type SelectProps = Omit<React.ComponentProps<typeof SelectPrimitive.Root<string>>, "onValueChange" | "value" | "defaultValue"> & {
+type SelectProps = Omit<
+  React.ComponentProps<typeof SelectPrimitive.Root<string>>,
+  "onValueChange" | "value" | "defaultValue"
+> & {
   value?: string;
   defaultValue?: string;
   onValueChange?: (value: string) => void;
@@ -41,7 +44,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "data-placeholder:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 aria-invalid:border-destructive flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-inset disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-placeholder:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 aria-invalid:border-destructive border-input flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-inset disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -92,7 +95,11 @@ function SelectLabel({ className, ...props }: React.ComponentProps<typeof Select
   );
 }
 
-function SelectItem({ className, children, ...props }: React.ComponentProps<typeof SelectPrimitive.Item>) {
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
   return (
     <SelectPrimitive.Item
       data-slot="select-item"

--- a/packages/ui/src/components/forms/slider.tsx
+++ b/packages/ui/src/components/forms/slider.tsx
@@ -5,14 +5,26 @@ import * as React from "react";
 
 import { cn } from "../../lib/utils";
 
-type SliderProps = Omit<React.ComponentProps<typeof SliderPrimitive.Root>, "onValueChange" | "value" | "defaultValue"> & {
+type SliderProps = Omit<
+  React.ComponentProps<typeof SliderPrimitive.Root>,
+  "onValueChange" | "value" | "defaultValue"
+> & {
   value?: number[];
   defaultValue?: number[];
   onValueChange?: (value: number[]) => void;
 };
 
 const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
-  ({ className, onValueChange, "aria-label": ariaLabel, "aria-labelledby": ariaLabelledby, ...props }, ref) => (
+  (
+    {
+      className,
+      onValueChange,
+      "aria-label": ariaLabel,
+      "aria-labelledby": ariaLabelledby,
+      ...props
+    },
+    ref,
+  ) => (
     <SliderPrimitive.Root
       ref={ref}
       className={cn("relative flex w-full touch-none items-center select-none", className)}
@@ -25,7 +37,7 @@ const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
       <SliderPrimitive.Thumb
         aria-label={ariaLabel ?? "Slider"}
         aria-labelledby={ariaLabelledby}
-        className="border-border focus-visible:border-ring focus-visible:bg-accent focus-visible:ring-ring block h-6 w-6 rounded-full border bg-background shadow-sm ring-1 ring-black/5 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+        className="border-border focus-visible:border-ring focus-visible:bg-accent focus-visible:ring-ring bg-background block h-6 w-6 rounded-full border shadow-sm ring-1 ring-black/5 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
       />
     </SliderPrimitive.Root>
   ),

--- a/packages/ui/src/components/forms/stepper.tsx
+++ b/packages/ui/src/components/forms/stepper.tsx
@@ -32,7 +32,7 @@ function Stepper({
   const atMax = value >= max;
 
   return (
-    <div className={cn("flex items-center rounded-lg border border-input bg-muted", className)}>
+    <div className={cn("border-input bg-muted flex items-center rounded-lg border", className)}>
       <Button
         type="button"
         variant="ghost"

--- a/packages/ui/src/components/forms/textarea.tsx
+++ b/packages/ui/src/components/forms/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "placeholder:text-muted-foreground aria-invalid:ring-destructive/20 aria-invalid:border-destructive focus-visible:ring-ring flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "placeholder:text-muted-foreground aria-invalid:ring-destructive/20 aria-invalid:border-destructive focus-visible:ring-ring border-input flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/layout/section-intro.tsx
+++ b/packages/ui/src/components/layout/section-intro.tsx
@@ -22,7 +22,7 @@ export function SectionIntro({ eyebrow, title, description, actions }: SectionIn
         ) : null}
         <div className="space-y-3">
           <h1 className="text-title-2 text-foreground font-semibold tracking-tight">{title}</h1>
-          {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
+          {description ? <p className="text-muted-foreground text-sm">{description}</p> : null}
         </div>
       </div>
       {actions ? <div className="shrink-0">{actions}</div> : null}

--- a/packages/ui/src/components/navigation/app-navigation.tsx
+++ b/packages/ui/src/components/navigation/app-navigation.tsx
@@ -83,7 +83,7 @@ export function AppNavigation({
     );
 
   return (
-    <header className="sticky top-0 z-50 flex w-full justify-center border-b bg-background/95 px-4 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+    <header className="bg-background/95 supports-[backdrop-filter]:bg-background/60 sticky top-0 z-50 flex w-full justify-center border-b px-4 backdrop-blur">
       <nav className="w-full max-w-7xl" aria-label={ariaLabel}>
         <div className="flex min-h-14 items-center justify-between gap-6">
           <div className="flex min-w-0 items-center">

--- a/packages/ui/src/components/navigation/pagination-controls.tsx
+++ b/packages/ui/src/components/navigation/pagination-controls.tsx
@@ -19,7 +19,7 @@ export function PaginationControls({
   }
 
   return (
-    <div className="text-sm text-muted-foreground flex items-center justify-end gap-2">
+    <div className="text-muted-foreground flex items-center justify-end gap-2 text-sm">
       <Button
         type="button"
         variant="outline"
@@ -31,7 +31,7 @@ export function PaginationControls({
         <ChevronLeft className="size-4" aria-hidden />
         Previous
       </Button>
-      <span className="text-xs text-foreground">
+      <span className="text-foreground text-xs">
         Page {currentPage + 1} of {totalPages}
       </span>
       <Button

--- a/packages/ui/src/components/overlays/alert-dialog.tsx
+++ b/packages/ui/src/components/overlays/alert-dialog.tsx
@@ -7,9 +7,14 @@ import { buttonVariants } from "../primitives/button";
 const AlertDialog = AlertDialogPrimitive.Root;
 const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
 
-const AlertDialogPortal = ({ children, ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) => (
+const AlertDialogPortal = ({
+  children,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) => (
   <AlertDialogPrimitive.Portal {...props}>
-    <div className="fixed inset-0 z-50 flex items-end justify-center sm:items-center">{children}</div>
+    <div className="fixed inset-0 z-50 flex items-end justify-center sm:items-center">
+      {children}
+    </div>
   </AlertDialogPrimitive.Portal>
 );
 
@@ -20,7 +25,7 @@ const AlertDialogOverlay = React.forwardRef<
   <AlertDialogPrimitive.Backdrop
     ref={ref}
     className={cn(
-      "bg-black/80 data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 z-50 transition-opacity",
+      "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 z-50 bg-black/80 transition-opacity",
       className,
     )}
     {...props}
@@ -36,7 +41,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Popup
       ref={ref}
       className={cn(
-        "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 border sm:data-open:slide-in-from-bottom-0 fixed bottom-0 z-50 grid w-full max-w-lg gap-6 rounded-t-xl p-4 outline-none sm:top-[50%] sm:right-auto sm:bottom-auto sm:left-[50%] sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-xl sm:p-6",
+        "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 sm:data-open:slide-in-from-bottom-0 fixed bottom-0 z-50 grid w-full max-w-lg gap-6 rounded-t-xl border p-4 outline-none sm:top-[50%] sm:right-auto sm:bottom-auto sm:left-[50%] sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-xl sm:p-6",
         className,
       )}
       {...props}
@@ -49,21 +54,34 @@ function AlertDialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDiv
 }
 
 function AlertDialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("flex flex-col-reverse gap-3 sm:flex-row sm:justify-end", className)} {...props} />;
+  return (
+    <div
+      className={cn("flex flex-col-reverse gap-3 sm:flex-row sm:justify-end", className)}
+      {...props}
+    />
+  );
 }
 
 const AlertDialogTitle = React.forwardRef<
   React.ComponentRef<typeof AlertDialogPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
 >(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Title ref={ref} className={cn("text-lg font-semibold tracking-tight", className)} {...props} />
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold tracking-tight", className)}
+    {...props}
+  />
 ));
 
 const AlertDialogDescription = React.forwardRef<
   React.ComponentRef<typeof AlertDialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Description ref={ref} className={cn("max-w-prose text-sm text-muted-foreground", className)} {...props} />
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-muted-foreground max-w-prose text-sm", className)}
+    {...props}
+  />
 ));
 
 const AlertDialogAction = React.forwardRef<
@@ -77,7 +95,11 @@ const AlertDialogCancel = React.forwardRef<
   React.ComponentRef<typeof AlertDialogPrimitive.Close>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Close>
 >(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Close ref={ref} className={cn(buttonVariants({ variant: "outline" }), "mt-2 sm:mt-0", className)} {...props} />
+  <AlertDialogPrimitive.Close
+    ref={ref}
+    className={cn(buttonVariants({ variant: "outline" }), "mt-2 sm:mt-0", className)}
+    {...props}
+  />
 ));
 
 export {

--- a/packages/ui/src/components/overlays/command.tsx
+++ b/packages/ui/src/components/overlays/command.tsx
@@ -4,26 +4,59 @@ import * as React from "react";
 
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "./dialog";
 
-function Command({ className, children, ...props }: Omit<React.ComponentProps<typeof CommandPrimitive.Root<string>>, "className"> & { className?: string }) {
+function Command({
+  className,
+  children,
+  ...props
+}: Omit<React.ComponentProps<typeof CommandPrimitive.Root<string>>, "className"> & {
+  className?: string;
+}) {
   return (
-    <div data-slot="command" className={`bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md ${className ?? ""}`}>
+    <div
+      data-slot="command"
+      className={`bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md ${className ?? ""}`}
+    >
       <CommandPrimitive.Root {...props}>{children}</CommandPrimitive.Root>
     </div>
   );
 }
 
-function CommandDialog({ title = "Command Palette", description = "Search for a command to run...", children, showCloseButton = true, ...props }: Omit<React.ComponentProps<typeof Dialog>, "children"> & { title?: string; description?: string; showCloseButton?: boolean; children?: React.ReactNode }) {
+function CommandDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  showCloseButton = true,
+  ...props
+}: Omit<React.ComponentProps<typeof Dialog>, "children"> & {
+  title?: string;
+  description?: string;
+  showCloseButton?: boolean;
+  children?: React.ReactNode;
+}) {
   return (
     <Dialog {...props}>
-      <DialogHeader className="sr-only"><DialogTitle>{title}</DialogTitle><DialogDescription>{description}</DialogDescription></DialogHeader>
-      <DialogContent className="overflow-hidden p-0" showCloseButton={showCloseButton}><Command>{children}</Command></DialogContent>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent className="overflow-hidden p-0" showCloseButton={showCloseButton}>
+        <Command>{children}</Command>
+      </DialogContent>
     </Dialog>
   );
 }
 
-type CommandInputProps = React.ComponentProps<typeof CommandPrimitive.Input> & { onValueChange?: (value: string) => void };
+type CommandInputProps = React.ComponentProps<typeof CommandPrimitive.Input> & {
+  onValueChange?: (value: string) => void;
+};
 
-function CommandInput({ className, onValueChange, onChange, "aria-label": ariaLabel = "Search commands", ...props }: CommandInputProps) {
+function CommandInput({
+  className,
+  onValueChange,
+  onChange,
+  "aria-label": ariaLabel = "Search commands",
+  ...props
+}: CommandInputProps) {
   return (
     <div data-slot="command-input-wrapper" className="flex h-9 items-center gap-2 border-b px-3">
       <SearchIcon className="size-4 shrink-0 opacity-50" />
@@ -31,7 +64,10 @@ function CommandInput({ className, onValueChange, onChange, "aria-label": ariaLa
         data-slot="command-input"
         aria-label={ariaLabel}
         className={`placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50 ${className ?? ""}`}
-        onChange={(event) => { onChange?.(event); onValueChange?.(event.currentTarget.value); }}
+        onChange={(event) => {
+          onChange?.(event);
+          onValueChange?.(event.currentTarget.value);
+        }}
         {...props}
       />
     </div>
@@ -41,7 +77,13 @@ function CommandInput({ className, onValueChange, onChange, "aria-label": ariaLa
 function CommandList({ children, ...props }: React.ComponentProps<typeof CommandPrimitive.List>) {
   if (typeof children === "function") {
     return (
-      <CommandPrimitive.List data-slot="command-list" aria-label="Command results" tabIndex={0} className="max-h-75 scroll-py-1 overflow-x-hidden overflow-y-auto" {...props}>
+      <CommandPrimitive.List
+        data-slot="command-list"
+        aria-label="Command results"
+        tabIndex={0}
+        className="max-h-75 scroll-py-1 overflow-x-hidden overflow-y-auto"
+        {...props}
+      >
         {children}
       </CommandPrimitive.List>
     );
@@ -57,7 +99,13 @@ function CommandList({ children, ...props }: React.ComponentProps<typeof Command
 
   return (
     <div data-slot="command-list-container" className="relative">
-      <CommandPrimitive.List data-slot="command-list" aria-label="Command results" tabIndex={0} className="max-h-75 scroll-py-1 overflow-x-hidden overflow-y-auto" {...props}>
+      <CommandPrimitive.List
+        data-slot="command-list"
+        aria-label="Command results"
+        tabIndex={0}
+        className="max-h-75 scroll-py-1 overflow-x-hidden overflow-y-auto"
+        {...props}
+      >
         {listChildren}
       </CommandPrimitive.List>
       {emptyChildren}
@@ -66,34 +114,89 @@ function CommandList({ children, ...props }: React.ComponentProps<typeof Command
 }
 
 function CommandEmpty({ ...props }: React.ComponentProps<typeof CommandPrimitive.Empty>) {
-  return <CommandPrimitive.Empty data-slot="command-empty" className="py-6 text-center text-sm" {...props} />;
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  );
 }
 
-function CommandGroup({ className, heading, children, ...props }: React.ComponentProps<typeof CommandPrimitive.Group> & { heading?: React.ReactNode }) {
+function CommandGroup({
+  className,
+  heading,
+  children,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group> & { heading?: React.ReactNode }) {
   return (
-    <CommandPrimitive.Group data-slot="command-group" className={`text-foreground overflow-hidden p-1 ${className ?? ""}`} {...props}>
-      {heading ? <CommandPrimitive.GroupLabel className="text-muted-foreground px-2 py-1.5 text-xs font-medium">{heading}</CommandPrimitive.GroupLabel> : null}
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={`text-foreground overflow-hidden p-1 ${className ?? ""}`}
+      {...props}
+    >
+      {heading ? (
+        <CommandPrimitive.GroupLabel className="text-muted-foreground px-2 py-1.5 text-xs font-medium">
+          {heading}
+        </CommandPrimitive.GroupLabel>
+      ) : null}
       {children}
     </CommandPrimitive.Group>
   );
 }
 
-type CommandItemProps = React.ComponentProps<typeof CommandPrimitive.Item> & { onSelect?: () => void };
+type CommandItemProps = React.ComponentProps<typeof CommandPrimitive.Item> & {
+  onSelect?: () => void;
+};
 
 function CommandItem({ className, onSelect, onClick, ...props }: CommandItemProps) {
-  return <CommandPrimitive.Item data-slot="command-item" className={`data-highlighted:bg-accent data-highlighted:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 ${className ?? ""}`} onClick={(event) => { onClick?.(event); onSelect?.(); }} {...props} />;
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={`data-highlighted:bg-accent data-highlighted:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 ${className ?? ""}`}
+      onClick={(event) => {
+        onClick?.(event);
+        onSelect?.();
+      }}
+      {...props}
+    />
+  );
 }
 
 function CommandSeparator({ className, ...props }: React.ComponentProps<"div">) {
-  return <div data-slot="command-separator" aria-hidden="true" className={`bg-border -mx-1 h-px ${className ?? ""}`} {...props} />;
+  return (
+    <div
+      data-slot="command-separator"
+      aria-hidden="true"
+      className={`bg-border -mx-1 h-px ${className ?? ""}`}
+      {...props}
+    />
+  );
 }
 
 function CommandShortcut(props: React.ComponentProps<"span">) {
-  return <span data-slot="command-shortcut" className="text-muted-foreground ml-auto text-xs tracking-widest" {...props} />;
+  return (
+    <span
+      data-slot="command-shortcut"
+      className="text-muted-foreground ml-auto text-xs tracking-widest"
+      {...props}
+    />
+  );
 }
 
 function CommandListLoading(props: React.ComponentProps<"div">) {
   return <div data-slot="command-list-loading" className="py-6 text-center text-sm" {...props} />;
 }
 
-export { Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandListLoading, CommandSeparator, CommandShortcut };
+export {
+  Command,
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandListLoading,
+  CommandSeparator,
+  CommandShortcut,
+};

--- a/packages/ui/src/components/overlays/dialog.tsx
+++ b/packages/ui/src/components/overlays/dialog.tsx
@@ -63,7 +63,7 @@ function DialogOverlay({ className, ...props }: React.ComponentProps<typeof Base
     <BaseDialog.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        "bg-black/80 data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 z-50 transition-opacity",
+        "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 z-50 bg-black/80 transition-opacity",
         className,
       )}
       {...props}
@@ -129,7 +129,7 @@ function DialogTitle({ className, ...props }: React.ComponentProps<typeof BaseDi
   return (
     <BaseDialog.Title
       data-slot="dialog-title"
-      className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+      className={cn("text-lg leading-none font-semibold tracking-tight", className)}
       {...props}
     />
   );
@@ -142,7 +142,7 @@ function DialogDescription({
   return (
     <BaseDialog.Description
       data-slot="dialog-description"
-      className={cn("max-w-prose text-sm text-muted-foreground", className)}
+      className={cn("text-muted-foreground max-w-prose text-sm", className)}
       {...props}
     />
   );

--- a/packages/ui/src/components/overlays/dropdown-menu.tsx
+++ b/packages/ui/src/components/overlays/dropdown-menu.tsx
@@ -12,11 +12,17 @@ function DropdownMenuPortal(props: React.ComponentProps<typeof DropdownMenuPrimi
   return <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />;
 }
 
-function DropdownMenuTrigger({ asChild, children, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger> & { asChild?: boolean }) {
+function DropdownMenuTrigger({
+  asChild,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger> & { asChild?: boolean }) {
   return (
     <DropdownMenuPrimitive.Trigger
       data-slot="dropdown-menu-trigger"
-      {...(asChild && React.isValidElement(children) ? { render: children as React.ReactElement } : {})}
+      {...(asChild && React.isValidElement(children)
+        ? { render: children as React.ReactElement }
+        : {})}
       {...props}
     >
       {!asChild && children}
@@ -24,7 +30,12 @@ function DropdownMenuTrigger({ asChild, children, ...props }: React.ComponentPro
   );
 }
 
-function DropdownMenuContent({ className, sideOffset = 4, children, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Popup> & { sideOffset?: number }) {
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Popup> & { sideOffset?: number }) {
   return (
     <DropdownMenuPrimitive.Portal>
       <DropdownMenuPrimitive.Positioner sideOffset={sideOffset}>
@@ -47,54 +58,159 @@ function DropdownMenuGroup(props: React.ComponentProps<typeof DropdownMenuPrimit
   return <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />;
 }
 
-function DropdownMenuLabel({ className, inset, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.GroupLabel> & { inset?: boolean }) {
-  return <DropdownMenuPrimitive.GroupLabel data-slot="dropdown-menu-label" data-inset={inset} className={cn("px-2 py-1.5 text-sm font-medium data-[inset]:pl-8", className)} {...props} />;
-}
-
-function DropdownMenuItem({ className, inset, variant = "default", ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & { inset?: boolean; variant?: "default" | "destructive" }) {
-  return <DropdownMenuPrimitive.Item data-slot="dropdown-menu-item" data-inset={inset} data-variant={variant} className={cn("data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:data-highlighted:bg-destructive/10 relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0", className)} {...props} />;
-}
-
-function DropdownMenuCheckboxItem({ className, children, checked, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.GroupLabel> & { inset?: boolean }) {
   return (
-    <DropdownMenuPrimitive.CheckboxItem data-slot="dropdown-menu-checkbox-item" className={cn("data-highlighted:bg-accent data-highlighted:text-accent-foreground relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50", className)} checked={checked} {...props}>
-      <span className="absolute left-2 flex size-3.5 items-center justify-center"><DropdownMenuPrimitive.CheckboxItemIndicator><CheckIcon className="size-4" /></DropdownMenuPrimitive.CheckboxItemIndicator></span>
+    <DropdownMenuPrimitive.GroupLabel
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn("px-2 py-1.5 text-sm font-medium data-[inset]:pl-8", className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean;
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:data-highlighted:bg-destructive/10 relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "data-highlighted:bg-accent data-highlighted:text-accent-foreground relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50",
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.CheckboxItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.CheckboxItemIndicator>
+      </span>
       {children}
     </DropdownMenuPrimitive.CheckboxItem>
   );
 }
 
-function DropdownMenuRadioGroup(props: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+function DropdownMenuRadioGroup(
+  props: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>,
+) {
   return <DropdownMenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />;
 }
 
-function DropdownMenuRadioItem({ className, children, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
   return (
-    <DropdownMenuPrimitive.RadioItem data-slot="dropdown-menu-radio-item" className={cn("data-highlighted:bg-accent data-highlighted:text-accent-foreground relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50", className)} {...props}>
-      <span className="absolute left-2 flex size-3.5 items-center justify-center"><DropdownMenuPrimitive.RadioItemIndicator><CircleIcon className="size-2 fill-current" /></DropdownMenuPrimitive.RadioItemIndicator></span>
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "data-highlighted:bg-accent data-highlighted:text-accent-foreground relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <span className="absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.RadioItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.RadioItemIndicator>
+      </span>
       {children}
     </DropdownMenuPrimitive.RadioItem>
   );
 }
 
-function DropdownMenuSeparator({ className, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
-  return <DropdownMenuPrimitive.Separator data-slot="dropdown-menu-separator" className={cn("bg-border -mx-1 my-1 h-px", className)} {...props} />;
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  );
 }
 
 function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<"span">) {
-  return <span className={cn("ml-auto text-xs tracking-widest opacity-60", className)} {...props} />;
+  return (
+    <span className={cn("ml-auto text-xs tracking-widest opacity-60", className)} {...props} />
+  );
 }
 
 function DropdownMenuSub(props: React.ComponentProps<typeof DropdownMenuPrimitive.SubmenuRoot>) {
   return <DropdownMenuPrimitive.SubmenuRoot data-slot="dropdown-menu-sub" {...props} />;
 }
 
-function DropdownMenuSubTrigger({ className, inset, children, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.SubmenuTrigger> & { inset?: boolean }) {
-  return <DropdownMenuPrimitive.SubmenuTrigger data-slot="dropdown-menu-sub-trigger" data-inset={inset} className={cn("data-highlighted:bg-accent data-highlighted:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-none select-none data-[inset]:pl-8", className)} {...props}>{children}<ChevronRightIcon className="ml-auto size-4" /></DropdownMenuPrimitive.SubmenuTrigger>;
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubmenuTrigger> & { inset?: boolean }) {
+  return (
+    <DropdownMenuPrimitive.SubmenuTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "data-highlighted:bg-accent data-highlighted:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-none select-none data-[inset]:pl-8",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubmenuTrigger>
+  );
 }
 
-function DropdownMenuSubContent({ className, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Popup>) {
-  return <DropdownMenuPrimitive.Popup data-slot="dropdown-menu-sub-content" className={cn("bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-lg outline-none", className)} {...props} />;
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Popup>) {
+  return (
+    <DropdownMenuPrimitive.Popup
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-lg outline-none",
+        className,
+      )}
+      {...props}
+    />
+  );
 }
 
 export {

--- a/packages/ui/src/components/overlays/popover.tsx
+++ b/packages/ui/src/components/overlays/popover.tsx
@@ -7,11 +7,17 @@ function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root
   return <PopoverPrimitive.Root data-slot="popover" {...props} />;
 }
 
-function PopoverTrigger({ asChild, children, ...props }: React.ComponentProps<typeof PopoverPrimitive.Trigger> & { asChild?: boolean }) {
+function PopoverTrigger({
+  asChild,
+  children,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger> & { asChild?: boolean }) {
   return (
     <PopoverPrimitive.Trigger
       data-slot="popover-trigger"
-      {...(asChild && React.isValidElement(children) ? { render: children as React.ReactElement } : {})}
+      {...(asChild && React.isValidElement(children)
+        ? { render: children as React.ReactElement }
+        : {})}
       {...props}
     >
       {!asChild && children}
@@ -35,7 +41,12 @@ function PopoverContent({
 }) {
   return (
     <PopoverPrimitive.Portal>
-      <PopoverPrimitive.Positioner align={align} side={side} sideOffset={sideOffset} collisionAvoidance={avoidCollisions ? undefined : { side: "none", align: "none" }}>
+      <PopoverPrimitive.Positioner
+        align={align}
+        side={side}
+        sideOffset={sideOffset}
+        collisionAvoidance={avoidCollisions ? undefined : { side: "none", align: "none" }}
+      >
         <PopoverPrimitive.Popup
           data-slot="popover-content"
           className={cn(

--- a/packages/ui/src/components/overlays/sheet.tsx
+++ b/packages/ui/src/components/overlays/sheet.tsx
@@ -8,10 +8,16 @@ import { cn } from "../../lib/utils";
 
 const Sheet = SheetPrimitive.Root;
 
-function SheetTrigger({ asChild, children, ...props }: React.ComponentProps<typeof SheetPrimitive.Trigger> & { asChild?: boolean }) {
+function SheetTrigger({
+  asChild,
+  children,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger> & { asChild?: boolean }) {
   return (
     <SheetPrimitive.Trigger
-      {...(asChild && React.isValidElement(children) ? { render: children as React.ReactElement } : {})}
+      {...(asChild && React.isValidElement(children)
+        ? { render: children as React.ReactElement }
+        : {})}
       {...props}
     >
       {!asChild && children}
@@ -19,10 +25,16 @@ function SheetTrigger({ asChild, children, ...props }: React.ComponentProps<type
   );
 }
 
-function SheetClose({ asChild, children, ...props }: React.ComponentProps<typeof SheetPrimitive.Close> & { asChild?: boolean }) {
+function SheetClose({
+  asChild,
+  children,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close> & { asChild?: boolean }) {
   return (
     <SheetPrimitive.Close
-      {...(asChild && React.isValidElement(children) ? { render: children as React.ReactElement } : {})}
+      {...(asChild && React.isValidElement(children)
+        ? { render: children as React.ReactElement }
+        : {})}
       {...props}
     >
       {!asChild && children}
@@ -38,7 +50,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Backdrop
     className={cn(
-      "bg-black/80 data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 z-50 transition-opacity",
+      "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 z-50 bg-black/80 transition-opacity",
       className,
     )}
     {...props}
@@ -86,7 +98,11 @@ const SheetTitle = React.forwardRef<
   React.ComponentRef<typeof SheetPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
 >(({ className, ...props }, ref) => (
-  <SheetPrimitive.Title ref={ref} className={cn("text-lg font-semibold tracking-tight", className)} {...props} />
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold tracking-tight", className)}
+    {...props}
+  />
 ));
 SheetTitle.displayName = SheetPrimitive.Title.displayName;
 
@@ -96,7 +112,7 @@ const SheetDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Description
     ref={ref}
-    className={cn("max-w-prose text-sm text-muted-foreground", className)}
+    className={cn("text-muted-foreground max-w-prose text-sm", className)}
     {...props}
   />
 ));

--- a/packages/ui/src/components/primitives/button.tsx
+++ b/packages/ui/src/components/primitives/button.tsx
@@ -10,16 +10,11 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default:
-          "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        outline:
-          "border-input bg-background hover:bg-accent hover:text-accent-foreground",
-        secondary:
-          "border-input bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost:
-          "border-transparent bg-transparent hover:bg-accent hover:text-accent-foreground",
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline: "border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary: "border-input bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "border-transparent bg-transparent hover:bg-accent hover:text-accent-foreground",
         link: "border-transparent bg-transparent px-0 text-primary underline-offset-4 hover:underline",
       },
       size: {
@@ -65,7 +60,9 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       const renderedChild = React.cloneElement(child, {
         children: isLoading ? (
           <>
-            <span className="opacity-0" aria-hidden="true">{child.props.children}</span>
+            <span className="opacity-0" aria-hidden="true">
+              {child.props.children}
+            </span>
             <span className="absolute inset-0 inline-flex items-center justify-center">
               <Spinner size="sm" aria-hidden="true" />
             </span>
@@ -105,7 +102,9 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       >
         {isLoading ? (
           <>
-            <span className="opacity-0" aria-hidden="true">{children}</span>
+            <span className="opacity-0" aria-hidden="true">
+              {children}
+            </span>
             <span className="absolute inset-0 inline-flex items-center justify-center">
               <Spinner size="sm" aria-hidden="true" />
             </span>

--- a/packages/ui/src/components/primitives/card.stories.tsx
+++ b/packages/ui/src/components/primitives/card.stories.tsx
@@ -21,7 +21,7 @@ export const Default: Story = {
         <CardDescription>A short description of the card's content.</CardDescription>
       </CardHeader>
       <CardContent>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-muted-foreground text-sm">
           Card body content goes here. It can be any React node.
         </p>
       </CardContent>
@@ -47,7 +47,7 @@ export const Minimal: Story = {
   render: () => (
     <Card className="w-80">
       <CardContent>
-        <p className="text-sm text-muted-foreground">Minimal card with only content.</p>
+        <p className="text-muted-foreground text-sm">Minimal card with only content.</p>
       </CardContent>
     </Card>
   ),

--- a/packages/ui/src/components/primitives/card.tsx
+++ b/packages/ui/src/components/primitives/card.tsx
@@ -6,10 +6,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card"
-      className={cn(
-        "bg-card text-card-foreground flex flex-col rounded-xl border",
-        className,
-      )}
+      className={cn("bg-card text-card-foreground flex flex-col rounded-xl border", className)}
       {...props}
     />
   );
@@ -36,7 +33,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-description"
-      className={cn("text-sm text-muted-foreground", className)}
+      className={cn("text-muted-foreground text-sm", className)}
       {...props}
     />
   );

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -43,46 +43,122 @@
   --color-chart-5: var(--color-border-strong);
 }
 
-@utility pb-safe-area-inset-bottom { padding-bottom: env(safe-area-inset-bottom); }
-@utility mb-safe-area-inset-bottom { margin-bottom: env(safe-area-inset-bottom); }
-@utility min-h-screen { min-height: 100vh; min-height: 100dvh; }
-@utility min-h-screen-dynamic { min-height: 100dvh; }
-@utility h-screen { height: 100vh; height: 100dvh; }
+@utility pb-safe-area-inset-bottom {
+  padding-bottom: env(safe-area-inset-bottom);
+}
+@utility mb-safe-area-inset-bottom {
+  margin-bottom: env(safe-area-inset-bottom);
+}
+@utility min-h-screen {
+  min-height: 100vh;
+  min-height: 100dvh;
+}
+@utility min-h-screen-dynamic {
+  min-height: 100dvh;
+}
+@utility h-screen {
+  height: 100vh;
+  height: 100dvh;
+}
 
 /* Shared layout rhythm. Product components own their layout; this does not
  * define visual component families. */
-.page-shell { @apply relative mx-auto flex w-full flex-col gap-12 px-4 py-16 md:gap-16 md:px-6 md:py-20; }
-.page-shell-detail { @apply relative mx-auto flex w-full flex-col gap-10 px-4 py-16 md:gap-12 md:px-6 md:py-20; }
-.page-bleed { @apply flex w-full flex-col; }
-.layout-stack { @apply flex flex-col gap-4; }
-.list-row { @apply flex gap-4 px-0 py-6 md:gap-6 md:py-8; }
-.list-media { @apply relative isolate flex shrink-0 items-center justify-center overflow-hidden rounded-md border border-border bg-card p-2 shadow-none; }
-.list-media-wide { @apply h-14 w-32; }
-.list-media-square { @apply size-10 sm:size-12; }
-.list-media-placeholder { @apply pointer-events-none absolute inset-0 flex items-center justify-center gap-1.5 transition-opacity duration-150; }
-.section { @apply flex flex-col gap-4 border-b border-border px-4 py-12 md:px-6 md:py-16; }
-.section-hero { @apply gap-6 py-16 md:py-20; }
-.detail-hero { @apply gap-4 py-10 md:gap-6 md:py-16; }
-.section-compact { @apply gap-4 py-8 md:py-12; }
-.detail-navigation { @apply flex flex-col gap-6 sm:flex-row sm:justify-between; }
-.detail-navigation-link { @apply flex min-h-11 flex-col justify-center gap-1; }
+.page-shell {
+  @apply relative mx-auto flex w-full flex-col gap-12 px-4 py-16 md:gap-16 md:px-6 md:py-20;
+}
+.page-shell-detail {
+  @apply relative mx-auto flex w-full flex-col gap-10 px-4 py-16 md:gap-12 md:px-6 md:py-20;
+}
+.page-bleed {
+  @apply flex w-full flex-col;
+}
+.layout-stack {
+  @apply flex flex-col gap-4;
+}
+.list-row {
+  @apply flex gap-4 px-0 py-6 md:gap-6 md:py-8;
+}
+.list-media {
+  @apply border-border bg-card relative isolate flex shrink-0 items-center justify-center overflow-hidden rounded-md border p-2 shadow-none;
+}
+.list-media-wide {
+  @apply h-14 w-32;
+}
+.list-media-square {
+  @apply size-10 sm:size-12;
+}
+.list-media-placeholder {
+  @apply pointer-events-none absolute inset-0 flex items-center justify-center gap-1.5 transition-opacity duration-150;
+}
+.section {
+  @apply border-border flex flex-col gap-4 border-b px-4 py-12 md:px-6 md:py-16;
+}
+.section-hero {
+  @apply gap-6 py-16 md:py-20;
+}
+.detail-hero {
+  @apply gap-4 py-10 md:gap-6 md:py-16;
+}
+.section-compact {
+  @apply gap-4 py-8 md:py-12;
+}
+.detail-navigation {
+  @apply flex flex-col gap-6 sm:flex-row sm:justify-between;
+}
+.detail-navigation-link {
+  @apply flex min-h-11 flex-col justify-center gap-1;
+}
 
 @layer base {
-  :root { color-scheme: light; }
-  @media (prefers-color-scheme: dark) { :root { color-scheme: dark; } }
-  html, body {
+  :root {
+    color-scheme: light;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      color-scheme: dark;
+    }
+  }
+  html,
+  body {
     background-color: var(--color-background);
     color: var(--color-foreground);
     font-family: var(--font-sans);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
-  * { border-color: var(--color-border, currentColor); }
-  *:focus { outline: none; }
-  *:focus-visible { outline: 2px solid var(--color-ring); outline-offset: 2px; border-radius: inherit; }
-  button { cursor: pointer; font-family: inherit; }
-  h1, h2, h3, h4, h5, h6 { font-family: var(--font-sans); font-weight: 600; letter-spacing: var(--tracking-tight); }
+  * {
+    border-color: var(--color-border, currentColor);
+  }
+  *:focus {
+    outline: none;
+  }
+  *:focus-visible {
+    outline: 2px solid var(--color-ring);
+    outline-offset: 2px;
+    border-radius: inherit;
+  }
+  button {
+    cursor: pointer;
+    font-family: inherit;
+  }
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--font-sans);
+    font-weight: 600;
+    letter-spacing: var(--tracking-tight);
+  }
   @media (prefers-reduced-motion: reduce) {
-    *, ::before, ::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; scroll-behavior: auto !important; }
+    *,
+    ::before,
+    ::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
   }
 }

--- a/packages/ui/src/tokens/color-systems.stories.tsx
+++ b/packages/ui/src/tokens/color-systems.stories.tsx
@@ -12,11 +12,29 @@ export const SystemAppearance: Story = {
     <main className="bg-background text-foreground grid min-h-screen gap-8 p-6 md:p-10">
       <header className="grid gap-2">
         <h1 className="text-2xl font-semibold">System color roles</h1>
-        <p className="text-muted-foreground max-w-prose text-sm">These semantic roles resolve from the operating system’s light or dark appearance. CSS is the single source of their values.</p>
+        <p className="text-muted-foreground max-w-prose text-sm">
+          These semantic roles resolve from the operating system’s light or dark appearance. CSS is
+          the single source of their values.
+        </p>
       </header>
-      <div className="flex flex-wrap gap-2"><Button>Primary action</Button><Button variant="secondary">Secondary action</Button><Button variant="outline">Outline action</Button><Button variant="destructive">Delete item</Button></div>
+      <div className="flex flex-wrap gap-2">
+        <Button>Primary action</Button>
+        <Button variant="secondary">Secondary action</Button>
+        <Button variant="outline">Outline action</Button>
+        <Button variant="destructive">Delete item</Button>
+      </div>
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
-        {colorTokenNames.map((token) => <div key={token} className="border-border grid min-h-20 content-end rounded-md border p-3" style={{ backgroundColor: `var(--color-${token})` }}><span className="bg-background text-foreground w-fit rounded px-1 font-mono text-xs">{token}</span></div>)}
+        {colorTokenNames.map((token) => (
+          <div
+            key={token}
+            className="border-border grid min-h-20 content-end rounded-md border p-3"
+            style={{ backgroundColor: `var(--color-${token})` }}
+          >
+            <span className="bg-background text-foreground w-fit rounded px-1 font-mono text-xs">
+              {token}
+            </span>
+          </div>
+        ))}
       </div>
     </main>
   ),

--- a/packages/ui/src/tokens/foundations.stories.tsx
+++ b/packages/ui/src/tokens/foundations.stories.tsx
@@ -6,27 +6,47 @@ type Story = StoryObj<typeof meta>;
 
 export const SpacingAndType: Story = {
   render: () => (
-    <main className="grid min-h-screen gap-10 bg-background p-6 text-foreground md:p-10">
+    <main className="bg-background text-foreground grid min-h-screen gap-10 p-6 md:p-10">
       <section className="grid gap-6">
         <header className="grid gap-2">
-          <p className="text-sm text-muted-foreground">Foundations / rhythm</p>
+          <p className="text-muted-foreground text-sm">Foundations / rhythm</p>
           <h1 className="text-4xl font-semibold tracking-tight">Tailwind defaults, directly.</h1>
-          <p className="max-w-2xl text-base text-muted-foreground">The specimen uses the shared Tailwind spacing and type scales.</p>
+          <p className="text-muted-foreground max-w-2xl text-base">
+            The specimen uses the shared Tailwind spacing and type scales.
+          </p>
         </header>
         <div className="grid gap-2">
           {[1, 2, 3, 4, 6, 8, 12, 16].map((size) => (
             <div key={size} className="flex items-center gap-3">
-              <span className="w-12 font-mono text-xs tabular-nums text-muted-foreground">{size}</span>
-              <div className="h-3 rounded-sm bg-accent" style={{ width: `calc(var(--spacing) * ${size})` }} aria-hidden="true" />
+              <span className="text-muted-foreground w-12 font-mono text-xs tabular-nums">
+                {size}
+              </span>
+              <div
+                className="bg-accent h-3 rounded-sm"
+                style={{ width: `calc(var(--spacing) * ${size})` }}
+                aria-hidden="true"
+              />
             </div>
           ))}
         </div>
       </section>
-      <section className="grid gap-5 rounded-xl border border-border bg-card p-6">
+      <section className="border-border bg-card grid gap-5 rounded-xl border p-6">
         <h2 className="text-2xl font-semibold">Typography scale</h2>
         <div className="grid gap-4">
-          {(["text-xs", "text-sm", "text-base", "text-lg", "text-xl", "text-2xl", "text-4xl"] as const).map((size) => (
-            <p key={size} className={`${size} text-foreground`}>{size}</p>
+          {(
+            [
+              "text-xs",
+              "text-sm",
+              "text-base",
+              "text-lg",
+              "text-xl",
+              "text-2xl",
+              "text-4xl",
+            ] as const
+          ).map((size) => (
+            <p key={size} className={`${size} text-foreground`}>
+              {size}
+            </p>
           ))}
         </div>
       </section>
@@ -36,10 +56,26 @@ export const SpacingAndType: Story = {
 
 export const Surfaces: Story = {
   render: () => (
-    <main className="grid min-h-screen gap-6 bg-background p-6 text-foreground md:p-10">
-      <header className="grid gap-2"><p className="text-sm text-muted-foreground">Foundations / surfaces</p><h1 className="text-4xl font-semibold tracking-tight">Standard semantic layers.</h1></header>
+    <main className="bg-background text-foreground grid min-h-screen gap-6 p-6 md:p-10">
+      <header className="grid gap-2">
+        <p className="text-muted-foreground text-sm">Foundations / surfaces</p>
+        <h1 className="text-4xl font-semibold tracking-tight">Standard semantic layers.</h1>
+      </header>
       <div className="grid gap-4 md:grid-cols-2">
-        {[["Background", "bg-background"], ["Card", "bg-card"], ["Popover", "bg-popover"], ["Muted", "bg-muted"]].map(([name, className]) => <div key={name} className={`${className} grid min-h-40 content-start gap-2 rounded-xl border border-border p-5`}><h2 className="text-lg font-semibold">{name}</h2><p className="text-sm text-muted-foreground">{className}</p></div>)}
+        {[
+          ["Background", "bg-background"],
+          ["Card", "bg-card"],
+          ["Popover", "bg-popover"],
+          ["Muted", "bg-muted"],
+        ].map(([name, className]) => (
+          <div
+            key={name}
+            className={`${className} border-border grid min-h-40 content-start gap-2 rounded-xl border p-5`}
+          >
+            <h2 className="text-lg font-semibold">{name}</h2>
+            <p className="text-muted-foreground text-sm">{className}</p>
+          </div>
+        ))}
       </div>
     </main>
   ),
@@ -47,12 +83,26 @@ export const Surfaces: Story = {
 
 export const Motion: Story = {
   render: () => (
-    <main className="grid min-h-screen gap-8 bg-background p-6 text-foreground md:p-10">
-      <header className="grid gap-2"><p className="text-sm text-muted-foreground">Foundations / motion</p><h1 className="text-4xl font-semibold tracking-tight">Motion stays standard and reducible.</h1></header>
+    <main className="bg-background text-foreground grid min-h-screen gap-8 p-6 md:p-10">
+      <header className="grid gap-2">
+        <p className="text-muted-foreground text-sm">Foundations / motion</p>
+        <h1 className="text-4xl font-semibold tracking-tight">
+          Motion stays standard and reducible.
+        </h1>
+      </header>
       <div className="grid gap-4 sm:grid-cols-3">
-        <div className="motion-safe:animate-in motion-safe:fade-in-0 grid min-h-32 place-content-center gap-2 rounded-xl border border-border bg-card p-5 motion-reduce:animate-none"><span className="text-lg font-semibold">Enter</span><span className="text-sm text-muted-foreground">150ms</span></div>
-        <button className="grid min-h-32 place-content-center gap-2 rounded-xl border border-border bg-card p-5 text-left transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none"><span className="text-lg font-semibold">Press</span><span className="text-sm text-muted-foreground">System focus</span></button>
-        <div className="grid min-h-32 place-content-center gap-2 rounded-xl border border-border bg-card p-5 motion-safe:animate-pulse motion-reduce:animate-none"><span className="text-lg font-semibold">Loading</span><span className="text-sm text-muted-foreground">Stable geometry</span></div>
+        <div className="motion-safe:animate-in motion-safe:fade-in-0 border-border bg-card grid min-h-32 place-content-center gap-2 rounded-xl border p-5 motion-reduce:animate-none">
+          <span className="text-lg font-semibold">Enter</span>
+          <span className="text-muted-foreground text-sm">150ms</span>
+        </div>
+        <button className="border-border bg-card hover:bg-accent focus-visible:ring-ring grid min-h-32 place-content-center gap-2 rounded-xl border p-5 text-left transition-colors focus-visible:ring-2 focus-visible:outline-none motion-reduce:transition-none">
+          <span className="text-lg font-semibold">Press</span>
+          <span className="text-muted-foreground text-sm">System focus</span>
+        </button>
+        <div className="border-border bg-card grid min-h-32 place-content-center gap-2 rounded-xl border p-5 motion-safe:animate-pulse motion-reduce:animate-none">
+          <span className="text-lg font-semibold">Loading</span>
+          <span className="text-muted-foreground text-sm">Stable geometry</span>
+        </div>
       </div>
     </main>
   ),

--- a/packages/ui/src/tokens/generated/foundations.css
+++ b/packages/ui/src/tokens/generated/foundations.css
@@ -39,9 +39,13 @@
   --spacing-scale-1-5: 0.375rem;
   --spacing-scale-2-5: 0.625rem;
   --spacing-scale-3-5: 0.875rem;
-  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', 'Noto Sans', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-  --font-serif: ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
-  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  --font-sans:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", Arial,
+    sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+  --font-mono:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+    monospace;
   --text-xs: 0.75rem;
   --text-sm: 0.875rem;
   --text-base: 1rem;

--- a/packages/ui/src/tokens/generated/foundations.generated.ts
+++ b/packages/ui/src/tokens/generated/foundations.generated.ts
@@ -56,14 +56,7 @@ export default {
       "Segoe UI Symbol",
       "Noto Color Emoji",
     ],
-    serif: [
-      "ui-serif",
-      "Georgia",
-      "Cambria",
-      "Times New Roman",
-      "Times",
-      "serif",
-    ],
+    serif: ["ui-serif", "Georgia", "Cambria", "Times New Roman", "Times", "serif"],
     mono: [
       "ui-monospace",
       "SFMono-Regular",

--- a/packages/ui/src/tokens/index.ts
+++ b/packages/ui/src/tokens/index.ts
@@ -13,9 +13,13 @@ const toBezier = (value: number[]) => `cubic-bezier(${value.join(", ")})`;
 type NormalizedSpacingKey<Key extends string> = Key extends `${infer Whole}-${infer Fraction}`
   ? `${Whole}.${Fraction}`
   : Key;
-export type SpacingToken = NormalizedSpacingKey<keyof typeof foundations["spacing-scale"] & string>;
+export type SpacingToken = NormalizedSpacingKey<
+  keyof (typeof foundations)["spacing-scale"] & string
+>;
 
-export const colorTokenNames = Object.keys(lightTokens.color) as Array<keyof typeof lightTokens.color>;
+export const colorTokenNames = Object.keys(lightTokens.color) as Array<
+  keyof typeof lightTokens.color
+>;
 export type ColorToken = keyof typeof lightTokens.color;
 export type ColorMode = "light" | "dark";
 export type ColorTheme = Readonly<Record<ColorToken, string>>;
@@ -34,7 +38,10 @@ export const colors = colorTokenNames.reduce(
 );
 
 export const spacing = Object.fromEntries(
-  Object.entries(foundations["spacing-scale"]).map(([key, value]) => [key.replace("-", "."), toPixels(value)]),
+  Object.entries(foundations["spacing-scale"]).map(([key, value]) => [
+    key.replace("-", "."),
+    toPixels(value),
+  ]),
 ) as Record<SpacingToken, number>;
 
 export const fontFamilies = Object.fromEntries(
@@ -48,7 +55,7 @@ export const textSizes = Object.fromEntries(
 export const textLineHeights = foundations["text-line-height"];
 export const fontWeights = Object.fromEntries(
   Object.entries(foundations["font-weight"]).map(([key, value]) => [key, String(value)]),
-) as Record<keyof typeof foundations["font-weight"], string>;
+) as Record<keyof (typeof foundations)["font-weight"], string>;
 export const tracking = foundations.tracking;
 export const leading = foundations.leading;
 export const radii = Object.fromEntries(

--- a/packages/ui/src/tokens/layout.stories.tsx
+++ b/packages/ui/src/tokens/layout.stories.tsx
@@ -1,13 +1,50 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-const meta = { title: "Foundations/Layout Rhythm", parameters: { layout: "fullscreen" } } satisfies Meta;
+const meta = {
+  title: "Foundations/Layout Rhythm",
+  parameters: { layout: "fullscreen" },
+} satisfies Meta;
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const PageShell: Story = {
-  render: () => <main className="page-shell bg-background text-foreground"><header className="flex flex-col gap-4"><p className="text-sm text-muted-foreground">Page shell</p><h1 className="text-4xl font-semibold tracking-tight">A consistent starting point for content pages.</h1></header><section className="flex flex-col gap-4"><h2 className="text-2xl font-semibold">Section rhythm</h2><p className="max-w-2xl text-base text-muted-foreground">Layout helpers compose standard Tailwind spacing and semantic colors.</p></section></main>,
+  render: () => (
+    <main className="page-shell bg-background text-foreground">
+      <header className="flex flex-col gap-4">
+        <p className="text-muted-foreground text-sm">Page shell</p>
+        <h1 className="text-4xl font-semibold tracking-tight">
+          A consistent starting point for content pages.
+        </h1>
+      </header>
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold">Section rhythm</h2>
+        <p className="text-muted-foreground max-w-2xl text-base">
+          Layout helpers compose standard Tailwind spacing and semantic colors.
+        </p>
+      </section>
+    </main>
+  ),
 };
 
 export const ListRows: Story = {
-  render: () => <main className="page-shell bg-background text-foreground"><div className="flex flex-col gap-4"><h1 className="text-4xl font-semibold tracking-tight">List row rhythm</h1><div className="divide-y divide-border border-b border-border">{["A compact row", "A readable row", "A responsive row"].map((title, index) => <div key={title} className="flex gap-4 py-6"><span className="font-mono text-sm text-muted-foreground">0{index + 1}</span><div className="flex min-w-0 flex-1 flex-col gap-1"><h2 className="text-lg font-semibold">{title}</h2><p className="text-sm text-muted-foreground">Consistent padding keeps scanning calm.</p></div></div>)}</div></div></main>,
+  render: () => (
+    <main className="page-shell bg-background text-foreground">
+      <div className="flex flex-col gap-4">
+        <h1 className="text-4xl font-semibold tracking-tight">List row rhythm</h1>
+        <div className="divide-border border-border divide-y border-b">
+          {["A compact row", "A readable row", "A responsive row"].map((title, index) => (
+            <div key={title} className="flex gap-4 py-6">
+              <span className="text-muted-foreground font-mono text-sm">0{index + 1}</span>
+              <div className="flex min-w-0 flex-1 flex-col gap-1">
+                <h2 className="text-lg font-semibold">{title}</h2>
+                <p className="text-muted-foreground text-sm">
+                  Consistent padding keeps scanning calm.
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </main>
+  ),
 };


### PR DESCRIPTION
**Note:** this PR includes two functional fixes in addition to the formatting pass below (flagged by review):
* `apps/voy`: `test` script no longer runs `jest --watchAll` (was hanging CI), test assertions now pass the required `penCapacity` argument, and `calculatePenDuration` now stops accumulating weeks once the pen is exhausted instead of over-counting from later dosages.
* `packages/ui`: `Accordion` no longer overwrites a caller-supplied `className` with its default `"w-full"` — the two are now merged with `cn()`.

---

This pull request primarily refactors JSX to improve code readability and maintainability by formatting long or complex props and children across multiple lines. It also ensures more consistent ordering of Tailwind CSS classes within className attributes, which can help with visual consistency and easier scanning of style intent.

The most important changes include:

**Code formatting and readability improvements:**

* Reformatted JSX elements, especially those with longer or nested children, to span multiple lines for improved readability (e.g., in `apps/labyrinth/app/routes/challenges.search-studio.tsx`, `apps/labyrinth/app/routes/challenges.fee-or-upfront.tsx`, `apps/health/app/routes/appointments.new.tsx`, and others). [[1]](diffhunk://#diff-ed1ad808b3d0956432026aed327c36860471f1b5321e662b51afde665e5bf2e9L353-R359) [[2]](diffhunk://#diff-bd13334af1ad83cb51e5833984e6457ab412d2ae827a32e15b0f1a6400bb9469L107-R109) [[3]](diffhunk://#diff-ae5077802c348bb42835ad996309e1eb0eb73d7494c77a3c6b23d16176e7909bL56-R59) [[4]](diffhunk://#diff-e18bb7196eccf79317a818c7cd6143edd3dbbc063b43cd8a51f455fe05566a62L700-R704) [[5]](diffhunk://#diff-3a0e2e6e92ea2f544c78fdea0ceae362154ed6c9afca3cfc1c1c5ea8826dde34L478-R480) [[6]](diffhunk://#diff-07e75d3c77eb27d0ce9dff7b9d2cc5bc5005071a9d2b8f888fd4fd4903bab775L134-R136) [[7]](diffhunk://#diff-33755794552fa4b598f853e154b4029841d576c2089b7aeb7f27e56c729edb32L21-R24) etc.)

* Broke up complex `className` expressions and ternaries over multiple lines for clarity, especially where conditional styling is applied. [[1]](diffhunk://#diff-ae5077802c348bb42835ad996309e1eb0eb73d7494c77a3c6b23d16176e7909bL79-R84) [[2]](diffhunk://#diff-ed1ad808b3d0956432026aed327c36860471f1b5321e662b51afde665e5bf2e9L241-R245)

**Tailwind CSS class consistency:**

* Reordered Tailwind CSS classes in `className` attributes for a more consistent and logical grouping, often placing color and text-related classes in a predictable order. [[1]](diffhunk://#diff-33755794552fa4b598f853e154b4029841d576c2089b7aeb7f27e56c729edb32L53-R58) [[2]](diffhunk://#diff-ffe9ae7dc279eb6a7347d9726ae38fd2d0029d330e04ead7970fb04064e4ddefL101-R105) [[3]](diffhunk://#diff-ffe9ae7dc279eb6a7347d9726ae38fd2d0029d330e04ead7970fb04064e4ddefL131-R159) [[4]](diffhunk://#diff-ffe9ae7dc279eb6a7347d9726ae38fd2d0029d330e04ead7970fb04064e4ddefL192-R198) [[5]](diffhunk://#diff-ffe9ae7dc279eb6a7347d9726ae38fd2d0029d330e04ead7970fb04064e4ddefL239-R245) [[6]](diffhunk://#diff-ffe9ae7dc279eb6a7347d9726ae38fd2d0029d330e04ead7970fb04064e4ddefL263-R269)
