### PR TITLE
fix(realitea): restore the accidentally commented-out How to play button

### DIFF
--- a/app/routes/games/realitea/route.tsx
+++ b/app/routes/games/realitea/route.tsx
@@ -307,7 +307,7 @@ export default function RealiTeaRoute() {
             alt="RealiTea"
             className="h-20 object-contain sm:h-14"
           />
-          {/* <Button
+          <Button
             aria-label="How to play"
             variant="ghost"
             className="self-end"
@@ -315,7 +315,7 @@ export default function RealiTeaRoute() {
             type="button"
           >
             <LucideHelpCircle />
-          </Button> */}
+          </Button>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary

- The latest `main` CI run (`lint-and-test`) was failing: `route.test.tsx` couldn't find `role="button" name=/how to play/i`.
- Cause: commit d741a87 ("Refactor CSS gap syntax in RealiTea components and remove unused header styles") wrapped the entire `<Button aria-label="How to play">` in a JSX comment while restyling the header, silently dropping it from render. This wasn't an intentional removal — `showInstructions`/`setShowInstructions` state, and the `Button`/`LucideHelpCircle` imports it depends on, were all left in place.
- Fix: uncomment the button, keeping the refactor's new `className="self-end"` header layout.

## Test plan

- [ ] `pnpm test` — confirm `route.test.tsx` passes now that the button renders again.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rba3QPJycsusZem15GgxoT)_