### PR TITLE
Add Connections design docs: API, word sourcing, game generation

### DIFF
--- a/docs/connections/__index.md
+++ b/docs/connections/__index.md
@@ -1,21 +1,12 @@
 ---
-title: Connections Case Study
-project: connections
-type: case-study
-status: active
-client: null
-industry: null
-owner: charlesponti
-tags:
-  - case-study
-  - game-design
-  - ai
-  - product-engineering
-related:
-  - ./api-design.md
-  - ./word-sourcing.md
-  - ./game-generation.md
+title: Connections
 summary: A Connections-style daily game for the software industry — same server-authoritative, generate-then-validate discipline RealiTea proved out, applied to a much harder content-validation problem.
+type: proposal
+status: proposed
+owner: charlesponti
+tags: [game-design, ai, product-engineering]
+related: [./api-design.md, ./word-sourcing.md, ./game-generation.md]
+updated: 2026-08-17
 ---
 
 # Connections

--- a/docs/connections/__index.md
+++ b/docs/connections/__index.md
@@ -1,0 +1,40 @@
+---
+title: Connections Case Study
+project: connections
+type: case-study
+status: active
+client: null
+industry: null
+owner: charlesponti
+tags:
+  - case-study
+  - game-design
+  - ai
+  - product-engineering
+related:
+  - ./api-design.md
+  - ./word-sourcing.md
+  - ./game-generation.md
+summary: A Connections-style daily game for the software industry — same server-authoritative, generate-then-validate discipline RealiTea proved out, applied to a much harder content-validation problem.
+---
+
+# Connections
+
+RealiTea proved that a small daily word game can hold up in production if the architecture draws a clean line: the server owns validation and publishing, the browser owns responsiveness, and nothing gets published without being checked against ground truth first. Connections is the same discipline applied to a harder problem — instead of validating one guessed word against a dictionary, it has to validate an entire self-consistent 16-word puzzle with no accidental overlaps, before a single tile is shown to a player.
+
+## The core reframe
+
+A game of Connections has 4 groups, but they aren't related to each other — the unit of content is a single 4-word **category group**, not a puzzle. Puzzles are assembled at serve time from a bank of independently-generated groups, subject to a reuse cooldown. That decoupling is what makes the rest of the design tractable: content generation and daily publishing become separate problems with separate failure modes, same as RealiTea's generation-vs-serving split.
+
+## Status
+
+- **Daily assembly** (picking 4 collision-free, off-cooldown groups and shuffling them into a grid) is prototyped, tested, and merged — see [game-generation.md](./game-generation.md#problem-1-daily-assembly--solved).
+- **Content generation** (producing the groups themselves) has a settled design, not yet built — see [game-generation.md](./game-generation.md#problem-2-content-generation--design-settled-build-pending).
+- **API shape** is settled — see [api-design.md](./api-design.md).
+- **Word/content sourcing** strategy is settled — see [word-sourcing.md](./word-sourcing.md).
+
+## Read next
+
+- [API design](./api-design.md)
+- [Word sourcing](./word-sourcing.md)
+- [Game generation](./game-generation.md)

--- a/docs/connections/api-design.md
+++ b/docs/connections/api-design.md
@@ -1,0 +1,125 @@
+---
+title: Connections API Design
+project: connections
+type: spec
+status: active
+client: null
+industry: null
+owner: charlesponti
+tags:
+  - api
+  - game-design
+  - react-router
+related:
+  - ./__index.md
+  - ./game-generation.md
+summary: The wire protocol for the software-industry Connections game — server-authoritative validation, a compact public puzzle payload, and index-based guesses.
+---
+
+# Connections API Design
+
+The API exists to keep one rule airtight: the client never receives the solution before the game is over. Everything else in this doc follows from that.
+
+## Why server-authoritative
+
+RealiTea already settled this question for daily word games in this repo — dictionary/answer data lives on the server, never in a payload the browser can inspect. Connections needs it even more than RealiTea does: RealiTea's answer is one word behind a dictionary check, but a Connections puzzle's entire content is 16 words and 4 labels sitting in one response. Shipping the grouping up front would make the game trivially solvable from the network tab.
+
+So the server is the only place that knows which word belongs to which group until the game ends (win or loss).
+
+## Endpoints
+
+Three endpoints, and the third may not even be necessary:
+
+```
+GET  /games/connections/:id
+POST /games/connections/:id/guess
+POST /games/connections/:id/complete   (possibly unnecessary — the server already
+                                         knows when the last group is solved)
+```
+
+This is a smaller surface than RealiTea's, which is expected: RealiTea also needs a standalone `/words/validate` endpoint because it accepts free-text dictionary guesses. Connections is a closed 16-word puzzle — there's no open-vocabulary validation to support.
+
+## Payload shapes
+
+### Initial load — `GET /games/connections/:id`
+
+Boring on purpose. No group labels, no grouping, no difficulty-to-word mapping — just the shuffled word list and the rules needed to render the board.
+
+```json
+{
+  "id": "2026-08-13",
+  "words": [
+    "CRYSTAL", "LOCK", "SPLIT", "THRONE",
+    "BASKET", "MAP", "CROWN", "BAIL",
+    "KEYBOARD", "FIRE", "DEPART", "CASTLE",
+    "EXIT", "PIANO", "SNOW", "CHECKMATE"
+  ],
+  "maxMistakes": 4
+}
+```
+
+This is exactly the shape `toGrid()` in `scripts/connections/picker.ts` already produces (4 groups flattened and shuffled into 16 words) — the picker's output maps directly onto this payload with no translation layer needed beyond assigning stable indexes.
+
+### Guess — `POST /games/connections/:id/guess`
+
+Indexes into `words`, not repeated strings. Smaller payload, and it sidesteps any guess-normalization ambiguity (case, punctuation) that string comparison would introduce.
+
+```json
+{ "guess": [1, 6, 11, 15] }
+```
+
+### Guess response
+
+Correct:
+
+```json
+{
+  "correct": true,
+  "group": {
+    "id": 3,
+    "label": "THINGS ASSOCIATED WITH A KING",
+    "items": [3, 6, 11, 15],
+    "difficulty": 2
+  }
+}
+```
+
+Incorrect, with the standard Connections "one away" hint (tells the player 3 of 4 were right, without saying which 3):
+
+```json
+{
+  "correct": false,
+  "mistakesRemaining": 2,
+  "oneAway": true
+}
+```
+
+### Game over — win or loss
+
+Full solution reveal, only now:
+
+```json
+{
+  "status": "won",
+  "mistakes": 2,
+  "groups": [
+    { "label": "THINGS WITH KEYS", "items": [1, 5, 8, 13], "difficulty": 0 },
+    { "label": "___ BALL", "items": [0, 4, 9, 14], "difficulty": 1 },
+    { "label": "WORDS MEANING LEAVE", "items": [2, 7, 10, 12], "difficulty": 2 },
+    { "label": "THINGS ASSOCIATED WITH A KING", "items": [3, 6, 11, 15], "difficulty": 3 }
+  ]
+}
+```
+
+## Deliberately deferred
+
+Two ideas came up while designing this that are worth recording as *not now*, not as rejected:
+
+- **Polymorphic game envelope** (`type: "connections" | "wordle" | "trivia"`). This generalizes the wire format before there's a second game that would benefit from it. RealiTea doesn't live behind a shared game abstraction today — it's its own route, its own table, its own API surface — and Connections should follow the same precedent until a real second case justifies the abstraction. Introducing it now is designing for a hypothetical.
+- **CDN-cacheable payloads, signed anonymous game tokens, zero-DB-read serving.** All legitimate scaling techniques, none of them relevant to a game that doesn't have a puzzle-generation pipeline yet. RealiTea itself doesn't do any of this — it serves a single daily record from the DB with a continuity fallback. Revisit if and when Connections has real traffic to justify it.
+
+## Read next
+
+- [Back to the overview](./__index.md)
+- [Word sourcing](./word-sourcing.md)
+- [Game generation](./game-generation.md)

--- a/docs/connections/api-design.md
+++ b/docs/connections/api-design.md
@@ -1,19 +1,12 @@
 ---
-title: Connections API Design
-project: connections
-type: spec
-status: active
-client: null
-industry: null
-owner: charlesponti
-tags:
-  - api
-  - game-design
-  - react-router
-related:
-  - ./__index.md
-  - ./game-generation.md
+title: API Design
 summary: The wire protocol for the software-industry Connections game — server-authoritative validation, a compact public puzzle payload, and index-based guesses.
+type: proposal
+status: proposed
+owner: charlesponti
+tags: [api, game-design, react-router]
+related: [./__index.md, ./word-sourcing.md, ./game-generation.md]
+updated: 2026-08-17
 ---
 
 # Connections API Design

--- a/docs/connections/game-generation.md
+++ b/docs/connections/game-generation.md
@@ -1,21 +1,12 @@
 ---
-title: Connections Game Generation
-project: connections
-type: spec
-status: active
-client: null
-industry: null
-owner: charlesponti
-tags:
-  - architecture
-  - ai
-  - game-design
-  - backend
-related:
-  - ./__index.md
-  - ./api-design.md
-  - ./word-sourcing.md
+title: Game Generation
 summary: How category groups get assembled into a daily puzzle without collisions, and the generate-then-validate architecture for producing the groups themselves.
+type: proposal
+status: proposed
+owner: charlesponti
+tags: [architecture, ai, game-design, backend]
+related: [./__index.md, ./api-design.md, ./word-sourcing.md]
+updated: 2026-08-17
 ---
 
 # Connections Game Generation

--- a/docs/connections/game-generation.md
+++ b/docs/connections/game-generation.md
@@ -1,0 +1,75 @@
+---
+title: Connections Game Generation
+project: connections
+type: spec
+status: active
+client: null
+industry: null
+owner: charlesponti
+tags:
+  - architecture
+  - ai
+  - game-design
+  - backend
+related:
+  - ./__index.md
+  - ./api-design.md
+  - ./word-sourcing.md
+summary: How category groups get assembled into a daily puzzle without collisions, and the generate-then-validate architecture for producing the groups themselves.
+---
+
+# Connections Game Generation
+
+Generation here is two separable problems: assembling a *daily puzzle* out of existing content (solved, prototyped, tested), and producing the *content* those puzzles draw from (design settled, not yet built).
+
+## Problem 1: daily assembly — solved
+
+Prototyped in `scripts/connections/` (merged in [PR #236](https://github.com/ponti-studios/labs/pull/236)), pure JS/TS, no database.
+
+**Model:** a category group (4 words, a label, a difficulty tier, and `riskWords` — words not in the group that a solver could plausibly mistake for members) is generated independently of any specific day. A daily puzzle is one group picked per difficulty tier (yellow/green/blue/purple), assembled at serve time, such that:
+
+- none of the 16 words repeat across the 4 chosen groups,
+- no word in one group is a risk word of another chosen group,
+- no group was used within a reuse cooldown window.
+
+**Picker:** randomized backtracking search over shuffled per-tier candidate lists (`scripts/connections/picker.ts`). Collision-free by construction, not by post-hoc filtering.
+
+**Bank sizing math:** with 4 groups used per day, a clean non-repeating rotation needs `groups per day × cooldown days` = `4 × 180 = 720` groups as the floor — one full pass through the bank *is* the cooldown period. Measured via simulation (`scripts/connections/simulate.ts`) at that exact floor: zero cooldown violations and zero failures across two full simulated years. Below that floor, the failure mode is running out of eligible groups for a tier, not backtracking cost — performance was never the bottleneck; at realistic scale it's ~4 attempts and <1ms per pick.
+
+This part of the system doesn't change based on where the groups came from. It consumes `CategoryGroup[]`, full stop.
+
+## Problem 2: content generation — design settled, build pending
+
+### The tag model
+
+A word's identity, for this purpose, isn't "one dictionary entry" — it's a set of tags from however many sources apply:
+
+- WordNet senses, each carrying a `lexName` (one of ~45 fixed semantic categories — see [word-sourcing.md](./word-sourcing.md)),
+- curated-list membership (`js-framework`, `http-method`, `git-command`, etc.).
+
+A word's full profile is the union. This one abstraction is what makes "words belong to multiple groups" tractable without building two parallel systems: enumerable categories are just "words sharing a curated-list tag," wordplay categories are "words with 2+ WordNet tags in different buckets," and the best category type — a proper noun that's also an ordinary English word with an unrelated meaning (`Rust`, `Go`, `Swift`, `Django`, `Vue`, `Svelte`) — falls out automatically as "words with a curated-list tag *and* a WordNet tag," no separate mechanism required.
+
+### Architectures considered for producing groups
+
+Six patterns, differing in where the LLM sits relative to the deterministic (WordNet/tag) layer:
+
+1. **LLM as last-mile curator** — deterministic clustering generates raw candidates, LLM picks the best 4 from each and writes the label. Cheap, bounded, but capped by what clustering surfaces.
+2. **LLM as generator, dictionary as verifier** — RealiTea's generate-then-validate loop, inverted onto this problem. LLM proposes groups directly; the picker's collision/riskWord logic (plus WordNet ground-truth checks) validates before anything is trusted. The only pattern that covers both wordplay *and* enumerable categories with one mechanism.
+3. **Hybrid** — cheap bulk LLM brainstorm of raw ideas, each wordplay claim checked against WordNet ground truth before being trusted, then an LLM pass for label/riskWords polish.
+4. **Embeddings instead of `lexName` clustering** — replaces the coarse 45-bucket taxonomy with gloss-embedding similarity clustering, raising the quality ceiling of the wordplay side specifically. Doesn't touch enumerable categories at all.
+5. **LLM as an offline batch curation job** — for expanding curated enumerable lists specifically; human-approved once, reused indefinitely under the cooldown window, not a per-puzzle runtime path.
+6. **LLM as adversarial solver (QA gate)** — orthogonal to all of the above. Before publishing a candidate puzzle, hand a second LLM the 16 shuffled words cold and see if it solves it the intended way. If it finds a *different* valid 4-group split, that's an unintended overlap the generator missed — reject and regenerate.
+
+### What the ungrounded example puzzle changes about this
+
+A test prompt to a general-purpose LLM ("come up with a Connections game") produced a coherent, collision-free puzzle — `MAP` for "Things With Keys" is real wordplay — with no access to WordNet, jargon-file, or any curated list. That's a concrete signal that pattern **#2** should be the primary path, not a fallback to pattern **#1**: the model already carries most of the associative/polysemy knowledge the clustering pipeline was trying to mine out of WordNet, so WordNet's job shifts from *primary generator* to *grounding layer* — confirm the LLM's claimed double-meaning is real, confirm no accidental overlap, don't take either on faith.
+
+This doesn't reduce the importance of validation; if anything it raises it. One good example is a capability signal, not a reliability track record, and the same model that produces a clean puzzle on one call is just as capable of confidently inventing a "double meaning" that doesn't hold up, or missing its own accidental overlap the way any generator can. That's precisely the discipline RealiTea's architecture already encodes (model generates, server never trusts it blind) and precisely why pattern **#6** — an independent adversarial solver — earns its place as a standing QA gate regardless of which generator produced the candidate: the failure mode it catches (an overlap the generator didn't notice about its own output) is structurally not something the generator can be trusted to catch about itself.
+
+**Recommended synthesis:** #2 as the primary generation path (reusing RealiTea's proven generate-validate-retry loop and the picker's already-built collision validator), #4 to raise the ceiling on the deterministic grounding layer specifically, #6 as a universal pre-publish QA gate. #1 and #5 are subsumed by #2 once it exists.
+
+## Read next
+
+- [Back to the overview](./__index.md)
+- [API design](./api-design.md)
+- [Word sourcing](./word-sourcing.md)

--- a/docs/connections/word-sourcing.md
+++ b/docs/connections/word-sourcing.md
@@ -1,0 +1,67 @@
+---
+title: Connections Word Sourcing
+project: connections
+type: spec
+status: active
+client: null
+industry: null
+owner: charlesponti
+tags:
+  - data
+  - nlp
+  - game-design
+  - ai
+related:
+  - ./__index.md
+  - ./game-generation.md
+summary: Where category-group words and their cross-domain overlaps come from — a curated software-industry seed pool, WordNet for grounding, and an LLM for generation, not the other way around.
+---
+
+# Connections Word Sourcing
+
+## The model: words, not puzzles, are the content unit
+
+A single game of Connections has 4 groups, but the groups aren't related to each other — they're independent. That means the unit of content isn't "a puzzle," it's a **category group** (4 words + a label + a difficulty tier + risk words). Puzzles are assembled at serve time by picking 4 off-cooldown groups (see [game-generation.md](./game-generation.md)). This doc is about where the groups themselves — and the words in them — come from.
+
+## Environment constraint that shaped this
+
+General web egress (Wikipedia, Datamuse, kaikki.org's Wiktionary dumps) is blocked by this sandbox's network policy. The npm registry is not — it's on the explicit allowlist alongside PyPI, crates.io, and a handful of others. That constraint, not preference, is why the sourcing below leans on npm-installable lexical data rather than live API calls or scraped dictionary dumps. If a future environment has broader egress, Wiktionary-via-kaikki.org would be a strictly richer source (explicit domain-labeled senses per word) worth revisiting.
+
+## Sources evaluated
+
+### `jargon-file` (npm)
+
+The actual Jargon File — hacker-culture terminology — shipped as JSON. 2,307 entries total; **1,256 single real words** after filtering out acronyms and multi-word phrases. This is the seed vocabulary for wordplay mining: real words the software industry actually uses, not a synthetic list.
+
+### `wordpos` (npm, wraps WordNet)
+
+For any word, returns every dictionary sense, each tagged with a `lexName` — one of WordNet's ~45 fixed lexicographer categories (`noun.food`, `noun.person`, `noun.communication`, `verb.contact`, etc.), plus hypernym pointers for finer-grained concept relationships. This is a real, pre-built semantic taxonomy — not something we hand-authored — and it's what makes cross-domain overlap detection a data query instead of a human noticing "oh, cracker is funny" by accident.
+
+Measured against the jargon-file pool: **359 of 1,256 words touch 2+ distinct `lexName` buckets** (a loose proxy for "has a tech sense and an unrelated sense"). Clustering those by shared bucket and taking `floor(bucket_size / 4)` gives an upper bound of **386 disjoint candidate groups** — but `lexName` is coarse (`noun.artifact` covers "any human-made object," which isn't a nameable category on its own), so real usable yield after quality filtering is a fraction of that, likely in the dozens-to-~150 range. See [game-generation.md](./game-generation.md) for how that yield compares against the bank size the picker actually needs.
+
+### `@cspell/dict-software-terms` (npm)
+
+A spellcheck dictionary with sub-lists for tools (`software-tools.txt`, 592 entries), networking terms, web services, and computing acronyms. Useful as raw material for **enumerable categories** (cloud providers, protocols, tool names) but it's a flat, uncategorized wordlist — "ArgoCD" and "Alacritty" sit next to each other with no signal grouping them into a clean theme like "Kubernetes Tools." Bootstrapping clean named categories out of this would require real re-curation work, not just filtering.
+
+### Hand-curated enumerable lists
+
+For category types WordNet fundamentally can't produce — "JS Frameworks," "HTTP Methods," "Git Commands" — because these are proper-noun set membership, not polysemy. WordNet has no entry for "React" the framework. These need either hand-authoring (fast, high-quality, what `fixtures.ts` already does for the picker prototype) or LLM-assisted drafting reviewed by a human once, since these lists get reused under the cooldown window rather than regenerated per puzzle.
+
+### The hybrid case — the best category type this game has access to
+
+Proper nouns from the enumerable lists that *also* happen to be ordinary WordNet words with an unrelated sense: `Rust`/rust (oxidation), `Go`/go, `Swift`/swift (bird), `Django`/Django (person/film), `Angular`/angular (adjective), `Vue`/view (homophone), `Svelte`/svelte (adjective, "slender"). This costs nothing extra to detect once a word's profile is modeled as a union of tags from both sources (WordNet senses + curated-list membership) — see the tag-model discussion in [game-generation.md](./game-generation.md).
+
+## The LLM reframes this doc's job
+
+A test prompt ("come up with a Connections game") produced a genuinely well-formed puzzle — including `MAP` for "Things With Keys" — with zero access to any of the above. That's a strong signal the model already has this associative/polysemy knowledge from training, and it shifts what this pipeline is actually for:
+
+- **Before this signal:** WordNet clustering was the primary *generator*; the LLM's role was mostly polish (pick the best 4 from a cluster, write a label).
+- **After this signal:** the LLM is the primary *generator* of both words and groupings — including the enumerable categories WordNet can't touch at all. WordNet, jargon-file, and the curated lists become the **grounding/verification layer**: is this claimed double-meaning real, per a source of truth, not per the model's say-so; is this claimed group free of the collisions our picker already knows how to detect.
+
+That mirrors RealiTea's existing discipline exactly — a model generates, the server never trusts it blind, ground truth validates before anything publishes. One good example doesn't establish a track record; it establishes that the generation side is worth building, with validation held to the same bar RealiTea already proved out.
+
+## Read next
+
+- [Back to the overview](./__index.md)
+- [API design](./api-design.md)
+- [Game generation](./game-generation.md)

--- a/docs/connections/word-sourcing.md
+++ b/docs/connections/word-sourcing.md
@@ -1,20 +1,12 @@
 ---
-title: Connections Word Sourcing
-project: connections
-type: spec
-status: active
-client: null
-industry: null
-owner: charlesponti
-tags:
-  - data
-  - nlp
-  - game-design
-  - ai
-related:
-  - ./__index.md
-  - ./game-generation.md
+title: Word Sourcing
 summary: Where category-group words and their cross-domain overlaps come from — a curated software-industry seed pool, WordNet for grounding, and an LLM for generation, not the other way around.
+type: proposal
+status: proposed
+owner: charlesponti
+tags: [data, nlp, game-design, ai]
+related: [./__index.md, ./api-design.md, ./game-generation.md]
+updated: 2026-08-17
 ---
 
 # Connections Word Sourcing


### PR DESCRIPTION
## Summary

Follow-up to #236 (merged). Records the design work for the software-industry Connections game as three docs under `docs/connections/`, matching RealiTea's frontmatter/structure convention (`docs/realitea/`):

- **`__index.md`** — overview and current status of each layer.
- **`api-design.md`** — the settled wire protocol: server-authoritative validation (no group labels or answers sent until game-over), a compact public puzzle payload matching the picker's `toGrid()` output, index-based guesses, the standard Connections "one away" hint. Also records what's deliberately deferred — a polymorphic multi-game envelope and CDN/scaling infra — as premature given RealiTea itself doesn't use either pattern today.
- **`word-sourcing.md`** — the data sources evaluated for category-group content (`jargon-file`, WordNet via `wordpos`, `@cspell/dict-software-terms`, hand-curated enumerable lists) with measured yield numbers, plus the reframe prompted by an ungrounded LLM test: the model already carries most of the associative/polysemy knowledge the WordNet pipeline was mining for, so it becomes the primary generator with WordNet/curated lists repositioned as the grounding/verification layer.
- **`game-generation.md`** — the two-part generation problem: daily assembly (solved — the picker from #236) vs. content generation (design settled, not yet built). Documents the tag model unifying WordNet senses and curated-list membership, six candidate LLM architectures, and the recommended synthesis (generate-then-validate + embedding-based clustering + an adversarial-solver QA gate).

No code changes — documentation only.

## Test plan

- [x] N/A — documentation only, no code changed.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01YKG1wnGVTLNU1qJZ4CDNv3

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKG1wnGVTLNU1qJZ4CDNv3)_