### PR TITLE
fix(realitea): close generation-lifecycle correctness bugs from PR #239 review

### DIFF
--- a/app/lib/realitea/admin/generate.server.ts
+++ b/app/lib/realitea/admin/generate.server.ts
@@ -310,7 +310,7 @@ async function runGenerationInBackground(
         costUsd: generated.usage.costUsd,
         finishedAt: new Date(),
       })
-      .where(eq(generationRuns.id, runId));
+      .where(and(eq(generationRuns.id, runId), eq(generationRuns.status, "running")));
 
     await recordAdminAction({
       hominemUserId: userId,
@@ -331,7 +331,7 @@ async function runGenerationInBackground(
     await db
       .update(generationRuns)
       .set({ status: "failed", llmError: getErrorMessage(err), finishedAt: new Date() })
-      .where(eq(generationRuns.id, runId));
+      .where(and(eq(generationRuns.id, runId), eq(generationRuns.status, "running")));
     publish({
       type: "stage",
       stage: "done",

--- a/app/lib/realitea/generation/generate.server.ts
+++ b/app/lib/realitea/generation/generate.server.ts
@@ -189,6 +189,17 @@ function usageFromResponse(
   reasoningEffort: string | undefined,
 ): GenerationUsage {
   const usage = response.usage;
+  // The OpenRouter SDK's docs claim cost is always included alongside token
+  // counts (no request-side opt-in field exists to set on this SDK
+  // version) — but that's unverified against a live response. If tokens
+  // came back but cost didn't, that's worth knowing about rather than
+  // silently persisting `null` forever. See docs/tasks/01-cost-tracking-silently-broken.md.
+  if (usage && (usage.promptTokens || usage.completionTokens) && usage.cost == null) {
+    logger.warn(
+      { event: "[GENERATION_USAGE_MISSING_COST]", usage },
+      "OpenRouter response included token usage but no cost — see docs/tasks/01-cost-tracking-silently-broken.md",
+    );
+  }
   return {
     requestedMaxTokens,
     reasoningEffort: reasoningEffort ?? null,
@@ -275,6 +286,7 @@ async function callGenerationApiForCandidates(
 async function callGenerationApi(
   game: GamesTopic,
   dateKey: string,
+  actor: string,
   excludedAnswers: string[],
   pendingArticles: Article[],
   systemPrompt: string,
@@ -303,32 +315,45 @@ async function callGenerationApi(
 
   if (llmError) {
     childLogger.error({ event: "[GENERATION_API_ERROR]", error: llmError }, "generation API call failed");
+    await recordGenerateFailure(game.id, dateKey, actor, "GENERATION_API_ERROR", { error: llmError });
     return { candidate: null, article: null, llmError, usage };
   }
 
-  for (const { candidate, validation } of candidates) {
-    const article = matchArticle(candidate, pendingArticles);
+  try {
+    for (const { candidate, validation } of candidates) {
+      const article = matchArticle(candidate, pendingArticles);
 
-    if (!article) {
+      if (!article) {
+        childLogger.warn(
+          { event: "[GENERATION_CANDIDATE_UNMATCHED]", answer: candidate.answer },
+          "candidate cited a source outside the offered article batch; skipping",
+        );
+        continue;
+      }
+
+      if (validation.valid) return { candidate, article, llmError: null, usage };
+
       childLogger.warn(
-        { event: "[GENERATION_CANDIDATE_UNMATCHED]", answer: candidate.answer },
-        "candidate cited a source outside the offered article batch; skipping",
+        {
+          event: "[GENERATION_CANDIDATE_REJECTED]",
+          answer: candidate.answer,
+          articleId: article.id,
+          reasons: validation.reasons,
+        },
+        "candidate rejected",
       );
-      continue;
+      await recordArticleRejection(article.id, validation.reasons.join("; "), MAX_ARTICLE_REJECTIONS);
     }
-
-    if (validation.valid) return { candidate, article, llmError: null, usage };
-
-    childLogger.warn(
-      {
-        event: "[GENERATION_CANDIDATE_REJECTED]",
-        answer: candidate.answer,
-        articleId: article.id,
-        reasons: validation.reasons,
-      },
-      "candidate rejected",
+  } catch (err) {
+    // Matching/scoring a candidate can hit the DB (recordArticleRejection). A
+    // failure here must fail this attempt only, not propagate out of
+    // generatePuzzleForGame and abort the rest of the cron run's dateKeys/games.
+    const matchError = getErrorMessage(err);
+    childLogger.error(
+      { event: "[GENERATION_MATCH_ERROR]", error: matchError },
+      "candidate matching/scoring failed",
     );
-    await recordArticleRejection(article.id, validation.reasons.join("; "), MAX_ARTICLE_REJECTIONS);
+    return { candidate: null, article: null, llmError: matchError, usage };
   }
 
   return { candidate: null, article: null, llmError: null, usage };
@@ -485,6 +510,7 @@ export async function generatePuzzleForGame(
     const attemptResult = await callGenerationApi(
       game,
       dateKey,
+      actor,
       excludedAnswers,
       pendingArticles,
       systemPrompt,

--- a/app/lib/realitea/generation/generate.server.ts
+++ b/app/lib/realitea/generation/generate.server.ts
@@ -1,5 +1,5 @@
 import { chatCompletion, getConfiguredTextModel, type ChatReasoningEffort } from "~/lib/server/ai";
-import { eq, gamesPuzzles, generationRuns, db } from "~/lib/server/db";
+import { and, eq, gamesPuzzles, generationRuns, db } from "~/lib/server/db";
 import type { Article, GamesTopic, GenerationEnvironment, ReasoningEffort } from "~/lib/server/db";
 import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
@@ -353,6 +353,7 @@ async function callGenerationApi(
       { event: "[GENERATION_MATCH_ERROR]", error: matchError },
       "candidate matching/scoring failed",
     );
+    await recordGenerateFailure(game.id, dateKey, actor, "GENERATION_MATCH_ERROR", { error: matchError });
     return { candidate: null, article: null, llmError: matchError, usage };
   }
 
@@ -531,7 +532,7 @@ export async function generatePuzzleForGame(
           costUsd: attemptResult.usage.costUsd,
           finishedAt: new Date(),
         })
-        .where(eq(generationRuns.id, run.id));
+        .where(and(eq(generationRuns.id, run.id), eq(generationRuns.status, "running")));
     }
 
     if (attemptResult.candidate && attemptResult.article) {

--- a/app/routes/games/realitea/admin/generate.tsx
+++ b/app/routes/games/realitea/admin/generate.tsx
@@ -82,6 +82,7 @@ export default function RealiTeaAdminGenerate() {
   // never depended on this component being mounted.
   useEffect(() => {
     if (data.activeRunId !== null) {
+      setRunning(true);
       setStage({
         type: "stage",
         stage: "model",

--- a/docs/tasks/00-index.md
+++ b/docs/tasks/00-index.md
@@ -1,0 +1,36 @@
+# RealiTea generation rework — correctness bugs
+
+Five correctness bugs surfaced by a code review of PR [#239](https://github.com/ponti-studios/labs/pull/239)'s
+base branch content — specifically the `feat(realitea): cost-tracked, resumable
+puzzle generation` change (`57ed331d`) that's now on `main`. All five were
+confirmed by re-reading the actual current code, not just diff inspection.
+
+Four are fixed (on branch `fix/realitea-generation-correctness-bugs`, not yet
+merged). The fifth (01) turned out to have a wrong root cause once actually
+investigated — see its ticket for the correction and what's instrumented
+instead of fixed.
+
+| # | Title | Severity | Status | File |
+|---|---|---|---|---|
+| [01](01-cost-tracking-silently-broken.md) | Cost tracking may record `null` on every run (root cause unconfirmed) | High if real | Open — instrumented | `app/lib/server/ai/index.ts` |
+| [02](02-reap-completion-race-overwrites-run-status.md) | Reap job and background completion handler race, can overwrite a succeeded run's status | Medium | Fixed | `app/lib/realitea/admin/generate.server.ts` |
+| [03](03-stale-running-flag-allows-duplicate-generation.md) | Resumed-run effect never sets `running`, admin can fire a duplicate generation | Medium | Fixed | `app/routes/games/realitea/admin/generate.tsx` |
+| [04](04-unguarded-candidate-loop-aborts-cron-run.md) | Unguarded candidate-matching loop can abort an entire cron invocation | Medium | Fixed | `app/lib/realitea/generation/generate.server.ts` |
+| [05](05-per-attempt-failures-missing-from-audit-trail.md) | Per-attempt LLM failures no longer recorded in the admin-action audit trail | Low | Fixed | `app/lib/realitea/generation/generate.server.ts` |
+
+## How these were found
+
+Via `/code-review` at medium effort: 8 independent finder angles (line-by-line
+scan, removed-behavior audit, cross-file call-site tracing, reuse,
+simplification, efficiency, altitude, and CLAUDE.md conventions) against
+`git diff main...HEAD` for the branch that became #239, followed by a
+one-vote verification pass per candidate finding. All five tickets below
+carry a `CONFIRMED` verdict from that verification pass — a separate agent
+re-read the actual files and named the exact trigger and wrong behavior,
+not just the diff.
+
+Three additional findings from the same review (a duplicated currency
+formatter, and two design notes about the background job's lack of a queue
+and the in-memory event bus's single-process scope) were already fixed
+directly in the codebase rather than filed as tickets — see commit
+`94b5de49` on the now-merged branch.

--- a/docs/tasks/01-cost-tracking-silently-broken.md
+++ b/docs/tasks/01-cost-tracking-silently-broken.md
@@ -1,0 +1,88 @@
+# 01 — Cost tracking may be recording `null` on every run (root cause unconfirmed)
+
+**Status:** Open — instrumented, not fixed. Original diagnosis was wrong; see below.
+**Category:** Correctness (suspected)
+**Severity:** High if real — defeats the stated purpose of the feature it ships with
+
+## Summary
+
+The `feat(realitea): cost-tracked, resumable puzzle generation` change
+(`57ed331d`) added per-run cost tracking (`costUsd` on `generationRuns`) and
+a whole admin dashboard to surface it (`/admin/costs`, per-run cost columns
+on the generations list and detail view).
+
+This ticket originally claimed the root cause was: "OpenRouter only returns
+`usage.cost` when the request opts in with `usage: {include: true}`, and the
+outgoing request never sets that flag." **That diagnosis does not hold up.**
+
+## Correction
+
+Inspecting the installed `@openrouter/sdk@1.2.6` directly (not just the
+diff):
+
+- `ChatRequest` (`chatrequest.d.ts`) has **no `usage`/`usage.include` field
+  at all** — not merely unset, it isn't part of the type, and the outbound
+  Zod schema used to serialize the request (`ChatRequest$outboundSchema`)
+  would silently strip any such key even if force-added via a type cast.
+  There is no code path — fixed or otherwise — that can set this flag on
+  this SDK version.
+- `ChatStreamOptions.includeUsage` (`chatstreamoptions.d.ts`), a related but
+  distinct field, carries this doc comment: *"Deprecated: This field has no
+  effect. Full usage details are always included."* That's the SDK stating
+  OpenRouter no longer requires a request-side opt-in for usage — it's
+  unconditional now, on this API version.
+
+So either `costUsd` isn't actually broken (usage really is always included,
+and the earlier review's finding was based on stale OpenRouter docs), or it
+is broken for some other reason entirely — a specific model/provider not
+reporting cost, a BYOK-key exemption, an account-level setting, or something
+not visible from static analysis. **This can only be settled by inspecting a
+real response from a live generation run**, which isn't possible from this
+environment (no API key, and it would cost real money to test speculatively).
+
+## What's been done
+
+Added a runtime signal instead of guessing: `usageFromResponse` in
+`app/lib/realitea/generation/generate.server.ts` now logs a
+`[GENERATION_USAGE_MISSING_COST]` warning whenever a response includes token
+counts but `usage.cost` is still `null`/`undefined`. The next real generation
+run (admin UI or cron) will make this observable either way:
+
+- If the warning **never fires** and `costUsd` starts showing real values on
+  `/admin/costs`, the feature was already working and this ticket is
+  invalid — close it.
+- If the warning **fires** on every run, the feature is genuinely broken for
+  a reason still to be identified — capture one full raw `response.usage`
+  payload from the log and continue investigating from there (check
+  OpenRouter's current dashboard/account settings for a cost-reporting
+  toggle, and confirm the specific model being used actually reports cost).
+
+## Evidence
+
+- `app/lib/server/ai/index.ts:93-100` — the `chatRequest` object passed to
+  `client.chat.send(...)`.
+- `node_modules/@openrouter/sdk/esm/models/chatrequest.d.ts` — `ChatRequest`
+  type, no `usage` field.
+- `node_modules/@openrouter/sdk/esm/models/chatstreamoptions.d.ts` —
+  `includeUsage` deprecation note.
+- `app/lib/realitea/generation/generate.server.ts` (`usageFromResponse`) —
+  now instrumented with the warning described above.
+- Downstream consumers that render `costUsd` and would be affected if this
+  turns out to be real: `app/routes/games/realitea/admin/costs.tsx`,
+  `generations.$id.tsx`, `inventory-list.tsx`, `route.tsx` (overview metric
+  card).
+
+## Why it matters
+
+If real, this is the headline feature of the commit ("cost-tracked... puzzle
+generation") silently doing nothing, with no error to surface it —
+`/admin/costs` would just render `$0.00`/`—` forever. That's still worth
+tracking even though the originally proposed fix was wrong.
+
+## Next step
+
+Watch the logs for `[GENERATION_USAGE_MISSING_COST]` after the next real
+generation run, or manually trigger one generation in a non-production
+environment and inspect the logged `usage` payload directly. Do not
+reintroduce the `usage: {include: true}` request field — it doesn't exist on
+this SDK version and won't compile/serialize.

--- a/docs/tasks/02-reap-completion-race-overwrites-run-status.md
+++ b/docs/tasks/02-reap-completion-race-overwrites-run-status.md
@@ -1,0 +1,78 @@
+# 02 — Reap job and background completion handler race, can overwrite a succeeded run's status
+
+**Status:** Fixed
+**Category:** Correctness / concurrency
+**Severity:** Medium — requires an unusually slow LLM call to trigger, but corrupts persisted state and misleads the admin UI when it does
+
+## Summary
+
+`reapStaleGenerations()` marks any `generationRuns` row still `status:
+"running"` after `REAP_AFTER_MS` (10 minutes) as `failed`. It's called on
+every admin overview/date page load (`inventory.ts:249,304`), not just at
+generation-start time. Meanwhile, `runGenerationInBackground`'s completion
+handler updates the row by `runId` alone, with no `WHERE status = 'running'`
+guard. If a run is genuinely still in flight past 10 minutes (slow model,
+not actually stuck) and an admin has the page open or reloads it, the reap
+job marks it `failed`; when the real LLM call finishes afterward, the
+completion handler unconditionally overwrites that back to
+`succeeded`/`failed` based on the real outcome — but the SSE stream already
+emitted a terminal "failed" event and closed, so the client never learns the
+row's true final state without a manual refresh.
+
+## Evidence
+
+- `app/lib/realitea/admin/generate.server.ts:42` — `REAP_AFTER_MS = 10 * 60 * 1000`.
+- `app/lib/realitea/admin/generate.server.ts:103-115` (`reapStaleGenerations`) —
+  updates any row where `status = 'running' AND createdAt < cutoff` to
+  `failed`, unconditionally.
+- `app/lib/realitea/admin/inventory.ts:249` and `:304` — `reapStaleGenerations()`
+  is called on both `loadAdminOverview` and `loadAdminDate`, i.e. on ordinary
+  page loads/reloads, not only when a new generation starts.
+- `app/lib/realitea/admin/generate.server.ts:313` and `:334` — both the
+  success and catch paths of `runGenerationInBackground`'s completion
+  handler do `.where(eq(generationRuns.id, runId))` with no additional
+  status predicate, so a row already marked `failed` by the reap job gets
+  silently overwritten.
+- `app/routes/games/realitea/admin/generate.stream.ts` — the SSE route's
+  `finish()` closes the stream and clears both the pub/sub subscription and
+  the poll timer on the first terminal event. There's no logic to reopen or
+  re-subscribe to `runId` after that, so a reap-triggered "failed" event
+  that arrives before the real completion is the client's last word on the
+  run, even though the row is later corrected in the database.
+
+## Why it matters
+
+Two admin-visible failure modes:
+
+1. **The persisted row is wrong for a window of time.** A run that
+   genuinely succeeded had its `status` briefly (or, if nobody reloads the
+   page again, indefinitely from the SSE client's perspective) shown as
+   `failed`, with `llmError: "reaped"` — a misleading, fabricated error on a
+   run that produced a real result.
+2. **The live view lies to the operator.** An admin watching a slow-but-fine
+   generation sees it flip to "failed" and stop updating, when it actually
+   succeeded moments later. They have no way to find out without manually
+   reloading the generations list.
+
+## Suggested fix
+
+Two independent, complementary changes:
+
+- Add `and(eq(generationRuns.status, "running"))` (or equivalent) to the
+  completion handler's `WHERE` clause at `generate.server.ts:313` and `:334`
+  so it never overwrites a row that's already left the `running` state —
+  this alone prevents the DB corruption, though the client may still have
+  seen a spurious terminal SSE event.
+- Consider whether `REAP_AFTER_MS` is actually long enough for the slowest
+  legitimate model/reasoning-effort combination in use, and/or whether
+  `reapStaleGenerations()` should run on a schedule instead of on every page
+  load, to reduce how often this race window opens at all.
+
+## Verification
+
+CONFIRMED by an independent verifier reading the exact lines in
+`generate.server.ts`, `inventory.ts`, and `generate.stream.ts` above and
+tracing the full causal chain — not inferred from the diff alone. The
+verifier found the completion handler's missing status guard to be worse
+than the original candidate finding assumed (no guard exists at all, so the
+DB row itself is corrupted, not just the SSE view).

--- a/docs/tasks/03-stale-running-flag-allows-duplicate-generation.md
+++ b/docs/tasks/03-stale-running-flag-allows-duplicate-generation.md
@@ -1,0 +1,66 @@
+# 03 — Resumed-run effect never sets `running`, admin can fire a duplicate generation
+
+**Status:** Fixed
+**Category:** Correctness / React state
+**Severity:** Medium
+
+## Summary
+
+The admin generate page seeds its `running` state once, from
+`data.activeRunId`, in the initial `useState` call. A separate effect exists
+to resume watching an in-progress run whenever `data.activeRunId` changes
+(e.g. after a loader revalidation), but that effect only calls `setStage(...)`
+and `watch(...)` — it never calls `setRunning(true)`. On an already-mounted
+page, a revalidation that surfaces a newly-active run id will start
+streaming its progress while the Generate button stays enabled and labeled
+"Generate" instead of "Generating," because `running` is still `false`.
+
+## Evidence
+
+- `app/routes/games/realitea/admin/generate.tsx:62` —
+  `const [running, setRunning] = useState(data.activeRunId !== null);` —
+  `running` is only ever seeded from `activeRunId` at mount time.
+- `app/routes/games/realitea/admin/generate.tsx:83-95` — the resume effect:
+  ```ts
+  useEffect(() => {
+    if (data.activeRunId !== null) {
+      setStage(...);
+      // ...
+      watch(data.activeRunId);
+    }
+  }, [data.activeRunId]);
+  ```
+  No `setRunning(true)` call anywhere in this effect.
+- `watch()` itself (around line 67-78) only ever calls `setRunning(false)`
+  on completion (line 75) — it never sets it `true` on start, because the
+  original caller of `watch()` (the submit handler, line 100) already calls
+  `setRunning(true)` explicitly before invoking it. The resume-effect path
+  bypasses that call site entirely.
+
+## Why it matters
+
+Failure scenario: an admin has `/generate` open with no active run
+(`running = false`). In another tab, or from another admin session, a
+generation is started for the same game. Back in the first tab, any loader
+revalidation that changes `data.activeRunId` without remounting the
+component (window focus refetch, `nav back`, React Router revalidation after
+an unrelated action) re-fires the effect and starts watching the new run —
+but `running` stays `false`, so the Generate button remains clickable and
+still reads "Generate." The admin can click it, firing a second concurrent
+generation for the same game/date while one is already streaming, wasting
+LLM cost and potentially racing two writes to the same `generationRuns`
+row's downstream state.
+
+## Suggested fix
+
+Add `setRunning(true)` inside the resume effect at
+`generate.tsx:83-95`, alongside the existing `setStage(...)`/`watch(...)`
+calls, so the button is disabled for the full duration the effect is
+actively watching a run — mirroring what the explicit submit-handler call
+site already does.
+
+## Verification
+
+CONFIRMED by an independent verifier reading the effect, its dependency
+array, and `watch()`'s own state transitions directly in
+`generate.tsx`.

--- a/docs/tasks/04-unguarded-candidate-loop-aborts-cron-run.md
+++ b/docs/tasks/04-unguarded-candidate-loop-aborts-cron-run.md
@@ -1,0 +1,77 @@
+# 04 — Unguarded candidate-matching loop can abort an entire cron invocation
+
+**Status:** Fixed
+**Category:** Correctness / error handling
+**Severity:** Medium
+
+## Summary
+
+Before `57ed331d`, `callGenerationApi` wrapped its entire body — the LLM call
+*and* the candidate-validation/matching loop that follows it — in one
+try/catch, reporting any failure via `recordGenerateFailure` and returning
+`null` so the caller could retry the next attempt. The rewritten version only
+catches exceptions from the LLM call itself
+(`callGenerationApiForCandidates`, which has its own internal try/catch); the
+candidate-matching loop that runs afterward — `matchArticle` plus
+`await recordArticleRejection(...)` per rejected candidate — is completely
+unguarded. If either of those throws, the exception now propagates all the
+way out of `callGenerationApi`, through `generatePuzzleForGame` (no
+try/catch), through the cron/gap-fill date-key loop (no try/catch), aborting
+the rest of that cron invocation instead of just failing the current
+attempt.
+
+## Evidence
+
+- `app/lib/realitea/generation/generate.server.ts:309-331` — the current
+  loop:
+  ```ts
+  for (const { candidate, validation } of candidates) {
+    const article = matchArticle(candidate, pendingArticles);
+    // ...
+    await recordArticleRejection(article.id, validation.reasons.join("; "), MAX_ARTICLE_REJECTIONS);
+  }
+  ```
+  has no surrounding try/catch. Compare to the pre-rewrite version (see
+  `git show 57ed331d^:app/lib/realitea/generation/generate.server.ts`),
+  which wrapped this same logic in the outer try/catch that also covered the
+  LLM call.
+- `generatePuzzleForGame` (same file, ~lines 459-493) calls `callGenerationApi`
+  inside its attempt-retry loop with no try/catch of its own — a throw here
+  aborts the whole function, not just the current attempt.
+- The cron entry points (`app/lib/realitea/ops.ts`, the `for (const dateKey
+  of ...)` loops around lines 132-136 and 149-153) also have no try/catch
+  around `generatePuzzleForGame` — a throw aborts the remaining
+  dateKeys/games in that invocation.
+- The actual top-level script (`scripts/realitea-generate.ts:144-154`) does
+  have a top-level `try { await main(); } catch { ...; process.exit(1); }
+  finally { closeDb(); }`, so the process itself won't crash unhandled — it
+  logs an error and exits cleanly. This limits the blast radius to "the rest
+  of this run is wasted," not "the process crashes uncleanly."
+
+## Why it matters
+
+`recordArticleRejection` does a DB write. If that write throws — a
+transient connection blip, a timeout, a constraint violation — the entire
+cron invocation's remaining work (every other dateKey and game scheduled for
+that run) is abandoned instead of just the current attempt being retried or
+skipped. The old code's per-call catch meant a single flaky DB write cost
+one attempt; the new code lets it cost the whole run.
+
+## Suggested fix
+
+Wrap the candidate-matching loop (`generate.server.ts:309-331`) in its own
+try/catch, converting a thrown error into the same kind of `llmError`/failed-
+attempt result the LLM-call path already produces, so a DB blip during
+scoring is treated as "this attempt failed, try the next one" rather than
+"abort everything downstream." Alternatively (or additionally), add a
+try/catch around each `generatePuzzleForGame` call in the cron date-key loop
+so one game's failure doesn't take out the rest of the batch.
+
+## Verification
+
+CONFIRMED by an independent verifier comparing the pre-rewrite version (via
+`git show 57ed331d^:...`) against the current file, and tracing every caller
+up to the top-level script's catch block. The verifier noted the practical
+severity is "a wasted cron run, not a crashed process" since
+`scripts/realitea-generate.ts` does catch at the top level — but the
+per-attempt retry behavior the old code had is still lost.

--- a/docs/tasks/05-per-attempt-failures-missing-from-audit-trail.md
+++ b/docs/tasks/05-per-attempt-failures-missing-from-audit-trail.md
@@ -1,0 +1,72 @@
+# 05 — Per-attempt LLM failures no longer recorded in the admin-action audit trail
+
+**Status:** Fixed
+**Category:** Observability
+**Severity:** Low
+
+## Summary
+
+Before `57ed331d`, every failed generation attempt inside the retry loop
+called `recordGenerateFailure(..., "GENERATION_API_ERROR", {error})` — an
+entry in the admin-action audit trail — even if a later attempt in the same
+call ultimately succeeded. The rewritten `callGenerationApi` only logs the
+failure via `childLogger.error(...)`; `recordGenerateFailure` is now called
+exactly once, only if *all* attempts in `generatePuzzleForGame`'s retry loop
+are exhausted (`GENERATION_EXHAUSTED`). A transient failure on attempt 1
+followed by a success on attempt 2 now leaves zero trace in the audit log.
+
+## Evidence
+
+- `app/lib/realitea/generation/generate.server.ts:305` — current failure
+  handling inside `callGenerationApi`:
+  ```ts
+  if (llmError) {
+    childLogger.error({ event: "[GENERATION_API_ERROR]", error: llmError }, "generation API call failed");
+    return { candidate: null, article: null, llmError, usage };
+  }
+  ```
+  No `recordGenerateFailure` call here.
+- `app/lib/realitea/generation/generate.server.ts:528` —
+  `recordGenerateFailure(game.id, dateKey, actor, "GENERATION_EXHAUSTED", {...})`
+  is the only remaining call site tied to attempt failures, reached only
+  after every attempt in the retry loop has failed.
+- Pre-rewrite version (`git show 57ed331d^:app/lib/realitea/generation/generate.server.ts`)
+  called `recordGenerateFailure(game.id, dateKey, "system:generate",
+  "GENERATION_API_ERROR", {error})` inside the same catch block, on every
+  failed attempt, regardless of whether a later attempt succeeded.
+
+## Partial mitigation already in place
+
+Each attempt now writes its own row to the new `generationRuns` table
+(status `"failed"`, `llmError`, token usage) — see
+`generate.server.ts:495-509`. So per-attempt failure data isn't entirely
+lost; it moved to a different table (`generationRuns`) than the admin-action
+audit log (`recordAdminAction`/`recordGenerateFailure`) this ticket is
+about. Anyone querying `generationRuns` directly can still reconstruct
+attempt-level failures. The gap is specifically in the human-facing
+admin-action audit trail that ops/on-call would check first.
+
+## Why it matters
+
+Lower severity than the other tickets in this set because the data isn't
+gone, just relocated to a table that isn't the first place someone
+debugging "why did generation seem flaky yesterday" would look. Worth fixing
+for consistency, not urgent.
+
+## Suggested fix
+
+Either restore a `recordGenerateFailure` (or a lighter-weight equivalent)
+call inside `callGenerationApi`'s `if (llmError)` branch at
+`generate.server.ts:305`, scoped per-attempt as before, or — if the
+`generationRuns` table is intended to fully supersede the admin-action audit
+trail for this specific event type — update whatever admin UI/runbook still
+points at `recordAdminAction`/`recordGenerateFailure` entries to also
+surface per-attempt rows from `generationRuns`, so the information is
+discoverable from one place either way.
+
+## Verification
+
+CONFIRMED by an independent verifier comparing the pre-rewrite version (via
+`git show 57ed331d^:...`) against the current file and confirming
+`recordGenerateFailure`'s only remaining attempt-related call site is the
+exhausted-retries path.


### PR DESCRIPTION
## Summary

Follow-up to #239's review — fixes 4 of 5 correctness bugs found in the `feat(realitea): cost-tracked, resumable puzzle generation` rework (`57ed331d`), all previously filed as tickets in `docs/tasks/`.

- **Reap/completion race** ([docs/tasks/02](docs/tasks/02-reap-completion-race-overwrites-run-status.md)): the background completion handler's DB update now requires `status = 'running'`, so `reapStaleGenerations` (called on every admin page load) can no longer race with a slow-but-successful run and have the outcome silently overwritten.
- **Stale `running` flag** ([docs/tasks/03](docs/tasks/03-stale-running-flag-allows-duplicate-generation.md)): the admin generate page's resume effect now sets `running` too, not just on initial mount — closes a path where a loader revalidation could leave the Generate button enabled over an already-streaming run.
- **Unguarded candidate loop** ([docs/tasks/04](docs/tasks/04-unguarded-candidate-loop-aborts-cron-run.md)): the candidate-matching loop is now wrapped in its own try/catch, so a DB error there fails just the current attempt instead of aborting the rest of a cron invocation.
- **Missing audit trail** ([docs/tasks/05](docs/tasks/05-per-attempt-failures-missing-from-audit-trail.md)): restored the per-attempt `GENERATION_API_ERROR` admin-action audit entry that the rewrite had dropped.

The 5th ticket (cost tracking recording `null`) is **not fixed** — the originally proposed root cause (missing `usage: {include: true}` request flag) doesn't hold up against the installed `@openrouter/sdk@1.2.6`'s actual types: there's no such field on this SDK version, and a sibling field's own deprecation note says usage is unconditionally included now. Rather than ship a fix that silently does nothing, added a `[GENERATION_USAGE_MISSING_COST]` warning log so the next real generation run makes the actual behavior observable. See [docs/tasks/01](docs/tasks/01-cost-tracking-silently-broken.md) for the full correction and next step.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `oxlint` clean on touched files
- [x] `vitest run app/lib/realitea app/routes/games/realitea` — 39 tests passing
- [ ] Watch for `[GENERATION_USAGE_MISSING_COST]` in logs after the next real generation run to resolve ticket 01

🤖 Generated with [Claude Code](https://claude.com/claude-code)