### PR TITLE
fix(glassmorphism): resolve Copilot review issues

### DIFF
--- a/app/routes/experiments.glass.tsx
+++ b/app/routes/experiments.glass.tsx
@@ -96,15 +96,25 @@ export default function ExperimentsGlass() {
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
-        entries.forEach((entry) => {
-          const index = sectionsRef.current.indexOf(entry.target as HTMLElement);
-          setVisibleSections((prev) => {
-            const next = new Set(prev);
-            if (entry.isIntersecting) {
+        setVisibleSections((prev) => {
+          let changed = false;
+          const next = new Set(prev);
+
+          entries.forEach((entry) => {
+            const index = sectionsRef.current.indexOf(entry.target as HTMLElement);
+            if (index < 0) return;
+
+            const isVisible = next.has(index);
+            if (entry.isIntersecting && !isVisible) {
               next.add(index);
+              changed = true;
+            } else if (!entry.isIntersecting && isVisible) {
+              next.delete(index);
+              changed = true;
             }
-            return next;
           });
+
+          return changed ? next : prev;
         });
       },
       { threshold: 0.1 },
@@ -765,7 +775,7 @@ export default function ExperimentsGlass() {
           animation-play-state: running;
         }
 
-        section:nth-child(n+2).visible {
+        section:nth-of-type(n+2).visible {
           animation-delay: 0.1s;
         }
       `}</style>

--- a/app/routes/experiments.glass.tsx
+++ b/app/routes/experiments.glass.tsx
@@ -24,12 +24,14 @@ export default function ExperimentsGlass() {
     "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/%22The_School_of_Athens%22_by_Raffaello_Sanzio_da_Urbino.jpg/1280px-%22The_School_of_Athens%22_by_Raffaello_Sanzio_da_Urbino.jpg",
   );
   const [controlsOpen, setControlsOpen] = useState(false);
+  const [visibleSections, setVisibleSections] = useState<Set<number>>(new Set());
   const dragRef = useRef({
     startX: 0,
     startY: 0,
     startMouseX: 0,
     startMouseY: 0,
   });
+  const sectionsRef = useRef<HTMLElement[]>([]);
 
   const handleDragStart = useCallback(
     (clientX: number, clientY: number) => {
@@ -65,8 +67,8 @@ export default function ExperimentsGlass() {
     if (!isDragging) return;
 
     const onMove = (e: MouseEvent | TouchEvent) => {
-      const clientX = e instanceof TouchEvent ? e.touches[0]?.clientX : (e as MouseEvent).clientX;
-      const clientY = e instanceof TouchEvent ? e.touches[0]?.clientY : (e as MouseEvent).clientY;
+      const clientX = "touches" in e ? e.touches[0]?.clientX : (e as MouseEvent).clientX;
+      const clientY = "touches" in e ? e.touches[0]?.clientY : (e as MouseEvent).clientY;
 
       if (clientX !== undefined && clientY !== undefined) {
         setPosition({
@@ -90,6 +92,30 @@ export default function ExperimentsGlass() {
       window.removeEventListener("touchend", onUp);
     };
   }, [isDragging]);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          const index = sectionsRef.current.indexOf(entry.target as HTMLElement);
+          setVisibleSections((prev) => {
+            const next = new Set(prev);
+            if (entry.isIntersecting) {
+              next.add(index);
+            }
+            return next;
+          });
+        });
+      },
+      { threshold: 0.1 },
+    );
+
+    sectionsRef.current.forEach((section) => {
+      if (section) observer.observe(section);
+    });
+
+    return () => observer.disconnect();
+  }, []);
 
   return (
     <div className="w-full bg-slate-950 text-white">
@@ -235,15 +261,16 @@ export default function ExperimentsGlass() {
           xmlns="http://www.w3.org/2000/svg"
           aria-label="Draggable glass effect"
           style={{
-            left: `${position.x}px`,
-            top: `${position.y}px`,
+            left: `calc(50% + ${position.x}px)`,
+            top: `calc(50% + ${position.y}px)`,
+            transform: "translate(-50%, -50%)",
             cursor: isDragging ? "grabbing" : "grab",
             overflow: "visible",
             width: "clamp(120px, 40vw, 220px)",
             height: "clamp(120px, 40vw, 220px)",
             willChange: isDragging ? "transform" : "auto",
           }}
-          className="absolute top-1/2 left-1/2 z-50 -translate-x-1/2 -translate-y-1/2 rounded-lg"
+          className="absolute z-50 rounded-lg"
           onMouseDown={handleMouseDown}
           onTouchStart={handleTouchStart}
         >
@@ -307,7 +334,12 @@ export default function ExperimentsGlass() {
           </div>
 
           {/* Section 1: Refraction Basics */}
-          <section className="space-y-6 sm:space-y-8">
+          <section
+            ref={(el) => {
+              if (el) sectionsRef.current[0] = el;
+            }}
+            className={cn("space-y-6 sm:space-y-8", visibleSections.has(0) ? "visible" : "")}
+          >
             <div>
               <h2 className="mb-3 text-2xl sm:text-3xl md:text-3xl font-bold">Part 1: Refraction & Snell's Law</h2>
               <div className="h-1 w-24 bg-gradient-to-r from-cyan-400 to-transparent" />
@@ -393,7 +425,12 @@ export default function ExperimentsGlass() {
           </section>
 
           {/* Section 2: Chromatic Aberration */}
-          <section className="space-y-8">
+          <section
+            ref={(el) => {
+              if (el) sectionsRef.current[1] = el;
+            }}
+            className={cn("space-y-8", visibleSections.has(1) ? "visible" : "")}
+          >
             <div>
               <h2 className="mb-3 text-2xl sm:text-3xl font-bold">Part 2: Chromatic Aberration</h2>
               <div className="h-1 w-24 bg-gradient-to-r from-cyan-400 to-transparent" />
@@ -473,7 +510,12 @@ export default function ExperimentsGlass() {
           </section>
 
           {/* Section 3: feDisplacementMap Mechanics */}
-          <section className="space-y-8">
+          <section
+            ref={(el) => {
+              if (el) sectionsRef.current[2] = el;
+            }}
+            className={cn("space-y-8", visibleSections.has(2) ? "visible" : "")}
+          >
             <div>
               <h2 className="mb-3 text-2xl sm:text-3xl font-bold">Part 3: How feDisplacementMap Works</h2>
               <div className="h-1 w-24 bg-gradient-to-r from-cyan-400 to-transparent" />
@@ -526,7 +568,12 @@ export default function ExperimentsGlass() {
           </section>
 
           {/* Section 4: Practical Implementation */}
-          <section className="space-y-8">
+          <section
+            ref={(el) => {
+              if (el) sectionsRef.current[3] = el;
+            }}
+            className={cn("space-y-8", visibleSections.has(3) ? "visible" : "")}
+          >
             <div>
               <h2 className="mb-3 text-2xl sm:text-3xl font-bold">Part 4: Building the Glass Effect</h2>
               <div className="h-1 w-24 bg-gradient-to-r from-cyan-400 to-transparent" />
@@ -616,7 +663,12 @@ export default function ExperimentsGlass() {
           </section>
 
           {/* Section 5: Why This Matters */}
-          <section className="space-y-8">
+          <section
+            ref={(el) => {
+              if (el) sectionsRef.current[4] = el;
+            }}
+            className={cn("space-y-8", visibleSections.has(4) ? "visible" : "")}
+          >
             <div>
               <h2 className="mb-3 text-2xl sm:text-3xl font-bold">Part 5: Why This Technique Matters</h2>
               <div className="h-1 w-24 bg-gradient-to-r from-cyan-400 to-transparent" />
@@ -705,10 +757,15 @@ export default function ExperimentsGlass() {
         }
 
         section {
-          animation: fadeInUp 0.6s ease-out;
+          animation: fadeInUp 0.6s ease-out forwards;
+          animation-play-state: paused;
         }
 
-        section:nth-child(n+2) {
+        section.visible {
+          animation-play-state: running;
+        }
+
+        section:nth-child(n+2).visible {
           animation-delay: 0.1s;
         }
       `}</style>


### PR DESCRIPTION
## Summary

Address three issues identified in Copilot review of the glassmorphism page:

1. **TouchEvent instanceof reference** — Unsafe reference to `TouchEvent` global can throw ReferenceError in non-touch environments (common on desktop browsers). Changed to structural check: `'touches' in e`.

2. **SVG positioning conflict** — Inline `left`/`top` styles from drag state conflicted with Tailwind `top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2` classes. The inline styles won but transforms still applied, offsetting the element by half its size. Now uses CSS `calc()` with a single `transform` property for clean centering math.

3. **Scroll animation timing** — Fade-in animations ran immediately on mount, completing before the user scrolled to the essay sections. Now uses Intersection Observer to trigger animations only when sections come into view.

## Technical Details

### TouchEvent Check
```typescript
// Before: Can throw ReferenceError
const clientX = e instanceof TouchEvent ? e.touches[0]?.clientX : ...

// After: Structural check, always safe
const clientX = "touches" in e ? e.touches[0]?.clientX : ...
```

### SVG Positioning
```typescript
// Before: Conflicting positioning
style={{ left: `${position.x}px`, top: `${position.y}px` }}
className="... top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 ..."

// After: Consolidated positioning
style={{
  left: `calc(50% + ${position.x}px)`,
  top: `calc(50% + ${position.y}px)`,
  transform: "translate(-50%, -50%)"
}}
className="absolute z-50 rounded-lg"
```

### Scroll-Triggered Animations
Added Intersection Observer hook to track when essay sections enter viewport, applying "visible" class to trigger fade-in animations only when needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjzPSQGGAz8a32vZDF23v3)_